### PR TITLE
netbox: re-enable 3.0.x builds and bump 3.1.x version

### DIFF
--- a/.github/workflows/build-netbox-container-image.yml
+++ b/.github/workflows/build-netbox-container-image.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - v3.1.0-ldap
+          - v3.0.12-ldap
+          - v3.1.1-ldap
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>