### PR TITLE
Add keycloak image

### DIFF
--- a/.github/workflows/build-keycloak-container-image.yml
+++ b/.github/workflows/build-keycloak-container-image.yml
@@ -1,0 +1,58 @@
+---
+name: Build keycloak container image
+
+"on":
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/build-keycloak-container-image.yml
+      - keycloak/**
+    branches:
+      - main
+  pull_request:
+    paths:
+      - .github/workflows/build-keycloak-container-image.yml
+      - keycloak/**
+
+jobs:
+
+  build-keycloak-container-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 16.1.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: keycloak
+          REPOSITORY: osism/keycloak
+          VERSION: ${{ matrix.version }}
+
+      - name: Push container image
+        run: |
+          scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: keycloak
+          REPOSITORY: osism/keycloak
+          VERSION: ${{ matrix.version }}
+        if: |
+          github.repository == 'osism/container-images' &&
+          github.ref == 'refs/heads/main'

--- a/keycloak/Containerfile
+++ b/keycloak/Containerfile
@@ -1,0 +1,13 @@
+ARG VERSION=16.1.0
+FROM jboss/keycloak:${VERSION}
+
+USER jboss
+
+# https://stackoverflow.com/questions/44624844/configure-reverse-proxy-for-keycloak-docker-with-custom-base-url
+
+# hadolint ignore=SC2086
+RUN sed -i -e 's/<web-context>auth<\/web-context>/<web-context>keycloak\/auth<\/web-context>/' $JBOSS_HOME/standalone/configuration/standalone.xml \
+    && sed -i -e 's/<web-context>auth<\/web-context>/<web-context>keycloak\/auth<\/web-context>/' $JBOSS_HOME/standalone/configuration/standalone-ha.xml \
+    && sed -i -e 's/name="\/"/name="\/keycloak\/"/' $JBOSS_HOME/standalone/configuration/standalone.xml \
+    && sed -i -e 's/name="\/"/name="\/keycloak\/"/' $JBOSS_HOME/standalone/configuration/standalone-ha.xml \
+    && sed -i -e 's/\/auth/\/keycloak\/auth"/' $JBOSS_HOME/welcome-content/index.html

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile


### PR DESCRIPTION
This image is necessary because we want to use Keycloak behind
raefik. In this case Keycloak is accessible via /keycloak/.
By default this does not work in the upstream Keycloak images.

Signed-off-by: Christian Berendt <berendt@osism.tech>