### PR TITLE
Fix ara-server image #40

### DIFF
--- a/ara-server/Containerfile
+++ b/ara-server/Containerfile
@@ -1,11 +1,11 @@
-ARG VERSION
+FROM python:3.9 as builder
 
-FROM pypy:3.7-slim as builder
+ARG VERSION=latest
 
 COPY files/requirements.txt /requirements.txt
 
 # hadolint ignore=DL3008,DL3013,SC2086
-RUN apt-get update \
+RUN echo $VERSION && apt-get update \
     && apt-get install -y --no-install-recommends \
       build-essential \
       gcc \
@@ -14,11 +14,11 @@ RUN apt-get update \
       libssl-dev \
       libyaml-dev \
     && mkdir /wheels \
-    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir -U pip \
     && python3 -m pip wheel --no-cache-dir --wheel-dir=/wheels -r /requirements.txt \
-    && if [ $VERSION != "latest" ]; then python3 -m pip wheel--no-cache-dir --wheel-dir=/wheels "ara[server]==$VERSION"; else python3 -m pip wheel --wheel-dir=/wheels --no-cache-dir "ara[server]"; fi
+    && if [ $VERSION != "latest" ]; then python3 -m pip wheel --no-cache-dir --wheel-dir=/wheels "ara[server]==$VERSION"; else python3 -m pip wheel --wheel-dir=/wheels --no-cache-dir "ara[server]"; fi
 
-FROM pypy:3.7-slim
+FROM python:3.9
 
 ENV TZ=UTC
 
@@ -28,17 +28,17 @@ COPY --from=builder /wheels /wheels
 COPY files/requirements.txt /requirements.txt
 COPY files/run.sh /run.sh
 
-# hadolint ignore=DL3008,SC2102
+# hadolint ignore=DL3008,DL3013,SC2102
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       curl \
       libmariadb3 \
-    && python3 -m pip install --no-cache-dir -U 'pip==21.0.1' \
+    && python3 -m pip install --no-cache-dir -U pip \
     && python3 -m pip install --no-cache-dir --no-index --find-links=/wheels -r /requirements.txt \
     && python3 -m pip install --no-cache-dir --no-index --find-links=/wheels ara[server] \
     && useradd ara-server \
     && chmod +x /wait \
-    && rm -rf /var/lib/apt/lists/* /wheels /requirements.txt \
+    && rm -rf /var/lib/apt/lists/* /wheels /requirements.txt
 
 USER ara-server
 WORKDIR /home/ara-server


### PR DESCRIPTION
For some unknown reason the current builds of the ara-server container
fail to initialize their database. Rebuild the container on the standard
python base.

Fix some bugs in the Containerfile along the way.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>