### PR TITLE
Stop running broken build actions

### DIFF
--- a/.github/workflows/build-awxclient-container-image.yml
+++ b/.github/workflows/build-awxclient-container-image.yml
@@ -3,8 +3,6 @@ name: Build awxclient container image
 
 "on":
   workflow_dispatch:
-  schedule:
-    - cron: "0 3 * * *"
   push:
     paths:
       - .github/workflows/build-awxclient-container-image.yml
@@ -23,7 +21,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 20.0.0
+          - 19.4.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-ceph-daemon-container-image.yml
+++ b/.github/workflows/build-ceph-daemon-container-image.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - v4.0.22-stable-4.0-nautilus
           - v5.0.14-stable-5.0-octopus
           - v6.0.6-stable-6.0-pacific
     steps:

--- a/.github/workflows/build-cephclient-container-image.yml
+++ b/.github/workflows/build-cephclient-container-image.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - nautilus
           - octopus
           - pacific
     steps:

--- a/.github/workflows/build-nova-libvirt-cloud-hypervisor-container-image.yml
+++ b/.github/workflows/build-nova-libvirt-cloud-hypervisor-container-image.yml
@@ -3,8 +3,6 @@ name: Build nova-libvirt-cloud-hypervisor container image
 
 "on":
   workflow_dispatch:
-  schedule:
-    - cron: "0 3 * * *"
   push:
     paths:
       - .github/workflows/build-nova-libvirt-cloud-hypervisor-container-image.yml


### PR DESCRIPTION
- Ceph nautilus image is no longer available upstream
- cloud-hypervisor builds are failing and need a fix
- Latest awx releases are missing on pypi

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>