### PR TITLE
ceph-daemon: remove zabbix-sender

### DIFF
--- a/ceph-daemon/Containerfile
+++ b/ceph-daemon/Containerfile
@@ -11,15 +11,6 @@ RUN groupmod -g 64045 ceph
 RUN find / -path /proc -prune -o -group 167 -exec chgrp -h ceph {} \;
 RUN find / -path /proc -prune -o -user 167 -exec chown -h ceph {} \;
 
-RUN yum update -y \
-    && yum clean all
-
-# Install zabbix-sender package to be able to use /usr/bin/zabbix_sender
-RUN centos_version="$(tr -dc '0-9.' < /etc/centos-release | cut -d \. -f1)" \
-    && rpm -Uvh "https://repo.zabbix.com/zabbix/5.1/rhel/${centos_version}/x86_64/zabbix-release-5.1-1.el${centos_version}.noarch.rpm" \
-    && yum install -y zabbix-sender \
-    && yum clean all
-
 LABEL "org.opencontainers.image.documentation"="https://docs.osism.tech" \
       "org.opencontainers.image.licenses"="ASL 2.0" \
       "org.opencontainers.image.source"="https://github.com/osism/container-images" \


### PR DESCRIPTION
We removed Zabbix a long time ago. This is a leftover
and can be removed.

Signed-off-by: Christian Berendt <berendt@osism.tech>