### PR TITLE
openstackclient: install osprofiler package

### DIFF
--- a/openstackclient/files/requirements.txt
+++ b/openstackclient/files/requirements.txt
@@ -2,6 +2,7 @@ aodhclient
 gnocchiclient
 keystoneauth-oidc
 osc-placement
+osprofiler
 prometheus-client
 python-barbicanclient
 python-blazarclient


### PR DESCRIPTION
Necessary to get results from osprofiler

Signed-off-by: Christian Berendt <berendt@osism.tech>