### PR TITLE
cephclient: reduze image size

### DIFF
--- a/cephclient/Containerfile
+++ b/cephclient/Containerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         apt-transport-https \
         bash-completion \
+        dumb-init \
         gpg-agent \
         software-properties-common \
         wget \
@@ -27,11 +28,13 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         ceph \
-        dumb-init \
         fio \
-        vim \
     && groupadd -g $GROUP_ID dragon \
     && useradd -g dragon -u $USER_ID -m -d /home/dragon dragon \
+    && apt-get remove -y \
+        apt-transport-https \
+        software-properties-common \
+        wget \
     && apt-get clean \
     && apt-get autoremove -y \
     && mkdir /configuration \


### PR DESCRIPTION
Remove packages that are no longer needed after the build.

This reduces the image size by about 500 MByte.

Signed-off-by: Christian Berendt <berendt@osism.tech>