### PR TITLE
netbox: install netbox-secretstore

### DIFF
--- a/netbox/requirements.txt
+++ b/netbox/requirements.txt
@@ -1,4 +1,5 @@
 netbox-bgp==0.6.1
-nextbox-ui-plugin==0.9.2
 netbox-dns==0.10.0
+netbox-secretstore==1.2.0
+nextbox-ui-plugin==0.9.2
 git+https://github.com/osism/netbox-plugin-osism.git@main


### PR DESCRIPTION
We need to store secrets for the deployment of the switch
configurations directly on the Netbox.

Signed-off-by: Christian Berendt <berendt@osism.tech>