### PR TITLE
openstackclient: install neutron-dynamic-routing

### DIFF
--- a/openstackclient/files/requirements.txt
+++ b/openstackclient/files/requirements.txt
@@ -1,6 +1,7 @@
 aodhclient
 gnocchiclient
 keystoneauth-oidc
+neutron-dynamic-routing
 osc-placement
 osprofiler
 prometheus-client


### PR DESCRIPTION
dragon@5f1790f4aed7:~$ openstack bgp
openstack: 'bgp' is not an openstack command. See 'openstack --help'.
Did you mean one of these?
  help
  ip availability list
  ip availability show

Related to osism/issues#209

Signed-off-by: Christian Berendt <berendt@osism.tech>