### PR TITLE
homer: remove v prefix

### DIFF
--- a/homer/Containerfile
+++ b/homer/Containerfile
@@ -4,8 +4,8 @@ ARG VERSION=v22.06.1  # renovate: datasource=docker depName=b4bz/homer
 
 WORKDIR /app
 
-ADD https://github.com/bastienwirtz/homer/archive/refs/tags/v${VERSION}.tar.gz /app
-RUN tar xvzf v${VERSION}.tar.gz
+ADD https://github.com/bastienwirtz/homer/archive/refs/tags/${VERSION}.tar.gz /app
+RUN tar xvzf ${VERSION}.tar.gz
 
 WORKDIR /app/homer-${VERSION}
 


### PR DESCRIPTION
The tag on Docker Hub seems to have changed. There is now a v.

Signed-off-by: Christian Berendt <berendt@osism.tech>