### PR TITLE
nexus: disable rebuilds

### DIFF
--- a/.github/workflows/build-nexus-container-image.yml
+++ b/.github/workflows/build-nexus-container-image.yml
@@ -3,8 +3,6 @@ name: Build nexus container image
 
 "on":
   workflow_dispatch:
-  schedule:
-    - cron: "0 3 * * *"
   push:
     paths:
       - .github/workflows/build-nexus-container-image.yml


### PR DESCRIPTION
There is no latest image of Nexus. Therefore, the rebuild makes no sense.

Signed-off-by: Christian Berendt <berendt@osism.tech>