### PR TITLE
homer: upstream container tag changed

### DIFF
--- a/homer/Containerfile
+++ b/homer/Containerfile
@@ -4,8 +4,8 @@ ARG VERSION=v22.07.2  # renovate: datasource=docker depName=b4bz/homer
 
 WORKDIR /app
 
-ADD https://github.com/bastienwirtz/homer/archive/refs/tags/v${VERSION}.tar.gz /app
-RUN tar xvzf v${VERSION}.tar.gz
+ADD https://github.com/bastienwirtz/homer/archive/refs/tags/${VERSION}.tar.gz /app
+RUN tar xvzf ${VERSION}.tar.gz
 
 WORKDIR /app/homer-${VERSION}
 


### PR DESCRIPTION
closes #132 

The upstream container tag introduced a prefix 'v' which now breaks our update automation causing a double 'v'. Therefore removed the hard coded 'v' in the container file.

Signed-off-by: Tim Beermann <beermann@osism.tech>
