### PR TITLE
ceph-daemon: wrong image tag

### DIFF
--- a/ceph-daemon/Containerfile
+++ b/ceph-daemon/Containerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM quay.io/ceph/daemon:$VERSION-centos-stream8
+FROM quay.io/ceph/daemon:$VERSION-centos-stream8-x86_64
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
upstream tags introduced a suffix '-x86_64' which is now added

Signed-off-by: Tim Beermann <beermann@osism.tech>
