### PR TITLE
netbox: use tag without -ldap

### DIFF
--- a/.github/workflows/build-netbox-container-image.yml
+++ b/.github/workflows/build-netbox-container-image.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - v3.2.5-ldap  # renovate: datasource=docker depName=quay.io/netboxcommunity/netbox
+          - v3.2.5  # renovate: datasource=docker depName=quay.io/netboxcommunity/netbox
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/netbox/Containerfile
+++ b/netbox/Containerfile
@@ -1,4 +1,4 @@
-ARG VERSION=v3.2.5-ldap  # renovate: datasource=docker depName=quay.io/netboxcommunity/netbox
+ARG VERSION=v3.2.5  # renovate: datasource=docker depName=quay.io/netboxcommunity/netbox
 FROM quay.io/netboxcommunity/netbox:${VERSION}
 
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
Upstream no longer builds the tag since version 3.2.5.

Closes osism/issues#376

Signed-off-by: Christian Berendt <berendt@osism.tech>