### PR TITLE
netbox: fix "Plugin netbox_bgp requires NetBox maximum version 3.3.99."

### DIFF
--- a/netbox/Containerfile
+++ b/netbox/Containerfile
@@ -12,6 +12,9 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
+# NOTE: Can be removed after merge & release of https://github.com/k01ek/netbox-bgp/pull/117
+COPY files/netbox-bgp-init.py /opt/netbox/venv/lib/python3.10/site-packages/netbox_bgp/__init__.py
+
 LABEL "org.opencontainers.image.documentation"="https://docs.osism.tech" \
       "org.opencontainers.image.licenses"="ASL 2.0" \
       "org.opencontainers.image.source"="https://github.com/osism/container-images" \

--- a/netbox/files/netbox-bgp-init.py
+++ b/netbox/files/netbox-bgp-init.py
@@ -1,0 +1,21 @@
+from extras.plugins import PluginConfig
+from .version import __version__
+
+
+class BGPConfig(PluginConfig):
+    name = 'netbox_bgp'
+    verbose_name = 'BGP'
+    description = 'Subsystem for tracking bgp related objects'
+    version = __version__
+    author = 'Nikolay Yuzefovich'
+    author_email = 'mgk.kolek@gmail.com'
+    base_url = 'bgp'
+    required_settings = []
+    min_version = '3.2.0'
+    max_version = '3.4.99'
+    default_settings = {
+        'device_ext_page': 'right',
+    }
+
+
+config = BGPConfig # noqa


### PR DESCRIPTION
This is a temporary workaround to be able to work with Netbox 3.4.

Can be removed after merge & release of
https://github.com/k01ek/netbox-bgp/pull/117

Signed-off-by: Christian Berendt <berendt@osism.tech>