### PR TITLE
Add aptly containers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/.github/workflows/build-aptly-container-image.yml
+++ b/.github/workflows/build-aptly-container-image.yml
@@ -1,0 +1,52 @@
+---
+name: Build aptly container image
+
+"on":
+  workflow_dispatch:
+    schedule:
+      - cron: "0 3 * * *"
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aptly/'
+      - '.github/workflows/build-aptly-container-image.yml'
+
+jobs:
+  build-aptly-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: aptly
+          REPOSITORY: osism/aptly
+          BUILD_OPTS: --build-context ./aptly --file Containerfile-aptly
+
+      - name: Push container image
+        run: |
+          scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE: aptly
+          REPOSITORY: osism/aptly
+        if: |
+          github.repository == 'osism/container-images' &&
+          github.ref == 'refs/heads/main'

--- a/.github/workflows/build-aptly-nginx-container-image.yml
+++ b/.github/workflows/build-aptly-nginx-container-image.yml
@@ -1,0 +1,52 @@
+---
+name: Build aptly nginx container image
+
+"on":
+  workflow_dispatch:
+    schedule:
+      - cron: "0 3 * * *"
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aptly/'
+      - '.github/workflows/build-aptly-nginx-container-image.yml'
+
+jobs:
+  build-aptly-nginx-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: aptly-nginx
+          REPOSITORY: osism/aptly-nginx
+          BUILD_OPTS: --build-context ./aptly --file Containerfile-nginx
+
+      - name: Push container image
+        run: |
+          scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE: aptly-nginx
+          REPOSITORY: osism/aptly-nginx
+        if: |
+          github.repository == 'osism/container-images' &&
+          github.ref == 'refs/heads/main'

--- a/.github/workflows/build-aptly-prepare-container-image.yml
+++ b/.github/workflows/build-aptly-prepare-container-image.yml
@@ -1,0 +1,52 @@
+---
+name: Build aptly prepare container image
+
+"on":
+  workflow_dispatch:
+    schedule:
+      - cron: "0 3 * * *"
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'aptly/'
+      - '.github/workflows/build-aptly-prepare-container-image.yml'
+
+jobs:
+  build-aptly-prepare-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup docker
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/main'
+
+      - name: Build container image
+        run: scripts/build.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          IMAGE: aptly-prepare
+          REPOSITORY: osism/aptly-prepare
+          BUILD_OPTS: --build-context ./aptly --file Containerfile-prepare
+
+      - name: Push container image
+        run: |
+          scripts/push.sh
+        env:
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE: aptly-prepare
+          REPOSITORY: osism/aptly-prepare
+        if: |
+          github.repository == 'osism/container-images' &&
+          github.ref == 'refs/heads/main'

--- a/aptly/Containerfile-aptly
+++ b/aptly/Containerfile-aptly
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+        gnupg1 \
+        gpgv1 \
+        python3 \
+        python3-pip \
+        screen \
+        xz-utils \
+    && curl -sL https://github.com/aptly-dev/aptly/releases/download/v1.5.0/aptly_1.5.0_amd64.deb --output /aptly.deb \
+    && dpkg -i /aptly.deb \
+    && rm /aptly.deb \
+    && curl -sL https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_amd64.tar.gz --output /yq.tar.gz \
+    && tar xzf yq.tar.gz ./yq_linux_amd64 \
+    && mv ./yq_linux_amd64 /usr/local/bin/yq \
+    && rm /yq.tar.gz \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY aptly.conf /etc/
+COPY requirements.txt /requirements.txt
+RUN pip3 install --no-cache-dir --no-deps -r /requirements.txt
+COPY main.py /main.py
+
+CMD ["python3", "/main.py"]

--- a/aptly/Containerfile-nginx
+++ b/aptly/Containerfile-nginx
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+COPY nginx.aptly.conf /etc/nginx/conf.d/default.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/aptly/Containerfile-prepare
+++ b/aptly/Containerfile-prepare
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gnupg1 \
+        gpgv1 \
+        moreutils \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["bash", "-c", "mkdir -p /opt/aptly/public; mkdir -p /opt/aptly/pool; while ! $(test -f /opt/aptly/public/gpgkey); do sleep 1; echo 'waiting for gpg key creation ...' | ts; done"]

--- a/aptly/README.md
+++ b/aptly/README.md
@@ -1,0 +1,15 @@
+# building the images locally
+
+```sh
+podman build --arch=amd64 -t aptly -f Containerfile-aptly
+podman build --arch=amd64 -t aptly-nginx -f Containerfile-nginx
+podman build --arch=amd64 -t aptly-prepare -f Containerfile-prepare
+```
+
+## rebuilding for developing
+
+```sh
+podman rm -f aptly && podman build --arch=amd64 -t aptly -f Containerfile-aptly && podman run -d --name aptly aptly && podman exec -it aptly bash
+podman rm -f aptly-nginx && podman build --arch=amd64 -t aptly-nginx -f Containerfile-nginx && podman run -d -p 8080:80 --name aptly-nginx aptly-nginx && podman exec -it aptly-nginx bash
+podman rm -f aptly-prepare && podman build --arch=amd64 -t aptly-prepare -f Containerfile-prepare && podman run -d --name aptly-prepare aptly-prepare && podman exec -it aptly-prepare bash
+```

--- a/aptly/aptly.conf
+++ b/aptly/aptly.conf
@@ -1,0 +1,24 @@
+{
+    "rootDir": "/opt/aptly",
+    "downloadConcurrency": 4,
+    "downloadSpeedLimit": 0,
+    "architectures": [
+        "amd64"
+    ],
+    "dependencyFollowSuggests": true,
+    "dependencyFollowRecommends": true,
+    "dependencyFollowAllVariants": false,
+    "dependencyFollowSource": false,
+    "dependencyVerboseResolve": false,
+    "gpgDisableSign": false,
+    "gpgDisableVerify": false,
+    "gpgProvider": "internal",
+    "downloadSourcePackages": false,
+    "skipLegacyPool": true,
+    "ppaDistributorID": "ubuntu",
+    "ppaCodename": "",
+    "skipContentsPublishing": false,
+    "FileSystemPublishEndpoints": {},
+    "S3PublishEndpoints": {},
+    "SwiftPublishEndpoints": {}
+}

--- a/aptly/main.py
+++ b/aptly/main.py
@@ -1,0 +1,188 @@
+import os
+import requests
+import subprocess
+import sys
+import time
+import yaml
+
+from munch import Munch
+from loguru import logger
+
+
+def prechecks() -> None:
+    # wait until gpg is present
+    counter = 0
+    while not os.path.exists('/opt/aptly/public/gpgkey'):
+        if counter == 0:
+            logger.info('WAITING FOR GPG KEY')
+        counter = counter + 1
+        if counter == 12:
+            counter = 0
+        time.sleep(5)
+
+    # check and wait for possible other running processes
+    counter = 0
+    while os.path.exists('/opt/aptly/aptly_wrapper.lock'):
+        if counter == 0:
+            logger.info('WAITING FOR OTHER JOB TO FINISH')
+        counter = counter + 1
+        if counter == 12:
+            counter = 0
+        time.sleep(5)
+
+    # create lock file to prevent parallel processes
+    with open('/opt/aptly/aptly_wrapper.lock', 'w') as file:
+        file.write(time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()))
+        file.write('\n')
+        file.write(os.getenv("HOSTNAME", ""))
+        file.write('\n')
+
+
+def get_global_config() -> Munch:
+    config = Munch()
+    for file in os.listdir('/opt/aptly_wrapper_config'):
+        if file.startswith('.'):
+            continue
+        with open(f"/opt/aptly_wrapper_config/{file}", 'r') as config_file:
+            config[file] = config_file.read().rstrip()
+
+    # check if we are running for the first time
+    config.update = os.path.exists('/opt/aptly/db')
+    if config.update:
+        config.mode = 'UPDATE'
+    else:
+        config.mode = 'INITIAL SETUP'
+
+    return config
+
+
+def runner(command: str) -> None:
+    logger.info(command)
+    # unfortunately we have to pipe directly to stdout as subprocess.PIPE would
+    # overflow within seconds due to the large amount of log messages generated
+    process = subprocess.Popen(
+        command,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        text=True,
+        shell=True
+    )
+    counter = 0
+    while True:
+        counter = counter + 1
+        if process.poll() is not None:
+            logger.info('PROCESS FINISHED')
+            break
+        else:
+            time.sleep(5)
+            if counter == 12:
+                counter = 0
+                logger.info('still working ...')
+
+
+def get_mirror_configs(sources_url: str) -> list:
+    result = requests.get(sources_url)
+    try:
+        mirror_configs = yaml.safe_load(result.content)['deb_mirrors']
+    except yaml.YAMLError as exc:
+        logger.critical(exc)
+    return mirror_configs
+
+
+def import_gpg_keys(mirror_configs: list) -> None:
+    for mirror_config in mirror_configs:
+        for gpg_url in mirror_config['gpg_urls']:
+            command = f"curl -sL '{gpg_url}' | gpg1 --no-default-keyring --keyring trustedkeys.gpg --import"
+            # for some unknown reason, gpg1 does not use stdout, so success messages will also be send to stderr :(
+            runner(command)
+
+
+def create_aptly_mirrors(mirror_configs: list, config: Munch) -> list:
+    mirror_names = []
+    for index, mirror_config in enumerate(mirror_configs):
+        mirror_name = f"mirror_{index:06d}"
+        mirror_names.append(mirror_name)
+
+        if not config.update:
+            command = f"aptly mirror create {mirror_name} {mirror_config['mirror']}"
+            runner(command)
+
+    return mirror_names
+
+
+def update_aptly_mirrors(mirror_names: list) -> None:
+    for mirror_name in mirror_names:
+        command = f"aptly mirror update {mirror_name}"
+        runner(command)
+
+
+def create_aptly_snapshots(mirror_names: list, config: Munch) -> list:
+    snapshot_names = []
+    for index, mirror_name in enumerate(mirror_names):
+        if config.update:
+            snapshot_name = f"snapshot_new_{index:06d}"
+        # initial setup
+        else:
+            snapshot_name = f"snapshot_{index:06d}"
+        snapshot_names.append(snapshot_name)
+
+        command = f"aptly snapshot create {snapshot_name} from mirror {mirror_name}"
+        runner(command)
+
+    return snapshot_names
+
+
+def merge(snapshot_names: list, config: Munch) -> None:
+    if config.update:
+        command = f"aptly snapshot merge {config.merged_mirror_name}-new"
+    else:
+        command = f"aptly snapshot merge {config.merged_mirror_name}"
+
+    for snapshot_name in snapshot_names:
+        command = f"{command} {snapshot_name}"
+    runner(command)
+
+
+def publish(config: Munch) -> None:
+    if config.update:
+        command = f"aptly publish switch -passphrase='{config.password}' {config.release} {config.merged_mirror_name} {config.merged_mirror_name}-new"
+    else:
+        command = f"aptly publish snapshot -distribution={config.release} -passphrase='{config.password}' {config.merged_mirror_name} {config.merged_mirror_name}"
+    runner(command)
+
+
+def cleanup(snapshot_names: list, config: Munch) -> None:
+    if config.update:
+        command = f"aptly snapshot drop {config.merged_mirror_name}"
+        runner(command)
+
+        for snapshot_new_name in snapshot_names:
+            snapshot_name = snapshot_new_name.replace("_new_", "_")
+            command = f"aptly snapshot drop {snapshot_name}"
+            runner(command)
+            command = f"aptly snapshot rename {snapshot_new_name} {snapshot_name}"
+            runner(command)
+
+        command = f"aptly snapshot rename {config.merged_mirror_name}-new {config.merged_mirror_name}"
+        runner(command)
+
+    os.remove('/opt/aptly/aptly_wrapper.lock')
+
+
+def main() -> None:
+    prechecks()
+    config = get_global_config()
+    logger.info(f"STARTED {config.mode}")
+    mirror_configs = get_mirror_configs(sources_url=config.sources_url)
+    import_gpg_keys(mirror_configs=mirror_configs)
+    mirror_names = create_aptly_mirrors(mirror_configs=mirror_configs, config=config)
+    update_aptly_mirrors(mirror_names=mirror_names)
+    snapshot_names = create_aptly_snapshots(mirror_names=mirror_names, config=config)
+    merge(snapshot_names=snapshot_names, config=config)
+    publish(config=config)
+    cleanup(snapshot_names=snapshot_names, config=config)
+    logger.info(f"FINISHED {config.mode}")
+
+
+if __name__ == '__main__':
+    main()

--- a/aptly/nginx.aptly.conf
+++ b/aptly/nginx.aptly.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name localhost;
+    location / {
+        root /opt/aptly/public;
+        autoindex on;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+}

--- a/aptly/requirements.txt
+++ b/aptly/requirements.txt
@@ -1,0 +1,10 @@
+PyYAML
+certifi
+chardet
+charset_normalizer
+idna
+loguru
+munch
+requests
+six
+urllib3

--- a/prometheus-arista-eos-exporter/Containerfile
+++ b/prometheus-arista-eos-exporter/Containerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && apk add --no-cache \
       dumb-init \
     && pip3 install --no-cache-dir -r /requirements.txt \
-    && pip3 install --no-cache-dir git+https://github.com/Showmax/arista-eos-exporter \
+    && pip3 install --no-cache-dir git+https://github.com/tibeer/arista-eos-exporter \
     && apk del .build-deps
 
 ENTRYPOINT ["usr/bin/dumb-init", "--", "python", "/usr/local/bin/main.py", "-c", "/config.yml"]


### PR DESCRIPTION
Aptly (and it's wrapper script) will be used to mirror a bunch of upstream repos.
Unfortunately, a preparation container, as well as a modded nginx are required to
consume aptly nearly fully automated. Only the GPG1 key needs to be created on first
installation within the preparation container (which terminates after succeeding):

```sh
gpg1 --gen-key
gpg1 --export --armor --output /opt/aptly/public/gpgkey OSISM
```

relates SovereignCloudStack/issues#334
relates osism/helm-charts#20

Signed-off-by: Tim Beermann <beermann@osism.tech>
