### PR TITLE
Revert "chore(deps): update dependency netbox-initializers to v3.5.1"

### DIFF
--- a/netbox/requirements.txt
+++ b/netbox/requirements.txt
@@ -1,6 +1,6 @@
 netbox-bgp==0.8.1
 netbox-dns==0.17.0
-netbox-initializers==3.5.1
+netbox-initializers==3.4.0
 netbox-secretstore==1.4.1
 nextbox-ui-plugin==0.13.0
 git+https://github.com/osism/netbox-plugin-osism.git@main


### PR DESCRIPTION
This reverts commit 4102c8cc9fc5429c127fd531513fbe77d4895d9b.

Not compatible with Netbox v3.4