### PR TITLE
cephclient: use package 'ceph-common' instead of 'ceph'

### DIFF
--- a/cephclient/Containerfile
+++ b/cephclient/Containerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-add-repository "deb https://download.ceph.com/debian-$VERSION/ bullseye main" \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        ceph \
+        ceph-common \
         fio \
     && groupadd -g $GROUP_ID dragon \
     && useradd -g dragon -u $USER_ID -m -d /home/dragon dragon \


### PR DESCRIPTION
The necessary packages are all included in ceph-common. It is not necessary to install everything from Ceph.