### PR TITLE
ceph-daemon: re-enable pacific build

### DIFF
--- a/.github/workflows/build-ceph-daemon-container-image.yml
+++ b/.github/workflows/build-ceph-daemon-container-image.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - latest-pacific
           - latest-quincy
     steps:
       - name: Checkout code


### PR DESCRIPTION
There was a surprising release of Pacific.

https://ceph.io/en/news/blog/2024/v16-2-15-pacific-released/