### PR TITLE
cephclient: handle debian version

### DIFF
--- a/cephclient/Containerfile
+++ b/cephclient/Containerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
         software-properties-common \
         wget \
     && wget -q -O- https://download.ceph.com/keys/release.asc | apt-key add - \
-    && apt-add-repository "deb https://download.ceph.com/debian-$VERSION/ bullseye main" \
+    && if [ $VERSION = "quincy" ]; then apt-add-repository --yes "deb https://download.ceph.com/debian-quincy/ bullseye main"; fi \
+    && if [ $VERSION = "reef" ]; then add-apt-repository --yes -c main -U https://download.ceph.com/debian-reef/; add-apt-repository --yes -c main -U https://download.ceph.com/debian-reef/; fi \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         ceph-common \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,12 +22,30 @@ if [[ -n $DOCKER_REGISTRY ]]; then
 fi
 
 pushd $IMAGE
-docker buildx build \
-    --load \
-    --build-arg "VERSION=$VERSION" \
-    --tag "$REPOSITORY:$REVISION" \
-    --label "org.opencontainers.image.created=$CREATED" \
-    --label "org.opencontainers.image.revision=$REVISION" \
-    --label "org.opencontainers.image.version=$VERSION" \
-    $BUILD_OPTS .
+if [[ $IMAGE == "cephclient" ]]; then
+    if [[ $VERSION == "quincy" ]]; then
+        DEBIAN_VERSION=bullseye
+    else
+	DEBIAN_VERSION=bookworm
+    fi
+
+    docker buildx build \
+      --load \
+      --build-arg "VERSION=$VERSION" \
+      --build-arg "DEBIAN_VERSION=$DEBIAN_VERSION" \
+      --tag "$REPOSITORY:$REVISION" \
+      --label "org.opencontainers.image.created=$CREATED" \
+      --label "org.opencontainers.image.revision=$REVISION" \
+      --label "org.opencontainers.image.version=$VERSION" \
+      $BUILD_OPTS .
+else
+    docker buildx build \
+      --load \
+      --build-arg "VERSION=$VERSION" \
+      --tag "$REPOSITORY:$REVISION" \
+      --label "org.opencontainers.image.created=$CREATED" \
+      --label "org.opencontainers.image.revision=$REVISION" \
+      --label "org.opencontainers.image.version=$VERSION" \
+      $BUILD_OPTS .
+fi
 popd


### PR DESCRIPTION
For quincy there are only bullseye packages.
For reef there are only bookworm packages.