### PR TITLE
openstackclient: install setuptools

### DIFF
--- a/openstackclient/files/requirements.txt
+++ b/openstackclient/files/requirements.txt
@@ -29,3 +29,4 @@ python-troveclient
 python-vitrageclient
 python-watcherclient
 python-zunclient
+setuptools


### PR DESCRIPTION
Could not load 'metric_resource-type_create': No module named 'distutils'
Could not load 'metric_resource-type_delete': No module named 'distutils'
Could not load 'metric_resource-type_list': No module named 'distutils'
Could not load 'metric_resource-type_show': No module named 'distutils'
Could not load 'metric_resource-type_update': No module named 'distutils'
Could not load 'metric_resource_batch_delete': No module named 'distutils'
Could not load 'metric_resource_create': No module named 'distutils'
Could not load 'metric_resource_delete': No module named 'distutils'
Could not load 'metric_resource_history': No module named 'distutils'
Could not load 'metric_resource_list': No module named 'distutils'
Could not load 'metric_resource_search': No module named 'distutils'
Could not load 'metric_resource_show': No module named 'distutils'
Could not load 'metric_resource_update': No module named 'distutils'