### PR TITLE
ansible-lint: Add explicit start to prepare-config

### DIFF
--- a/ansible-lint/files/prepare-config.py
+++ b/ansible-lint/files/prepare-config.py
@@ -9,4 +9,6 @@ conf = hiyapyco.load(
 )
 
 with open("/zuul/.ansible-lint", "w+") as fp:
-    fp.write(hiyapyco.dump(conf, default_flow_style=True))
+    fp.write(hiyapyco.dump(conf,
+                           default_flow_style=True,
+                           explicit_start=True))


### PR DESCRIPTION
Since ansible-lint-24.10.0, the parsing of the config is partially failing if the yaml in to config file isn't preceded by the "---" marker. Make sure that it is preserved in the merged config file.