### PR TITLE
openstackclient: set CFLAGS="-Wno-int-conversion"

### DIFF
--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -8,6 +8,13 @@ ARG GROUP_ID=45000
 
 COPY files/requirements.txt /requirements.txt
 
+# This solves the following problem. It can be removed in the future if
+# netifaces is no longer used as a dependency of the OpenStack SDK.
+#
+# netifaces.c:1808:9: error: initialization of 'int' from 'void *' makes
+# integer from pointer without a cast [-Wint-conversion]
+ENV CFLAGS="-Wno-int-conversion"
+
 RUN apk update --no-cache \
     && apk upgrade --no-cache --available \
     && apk add --no-cache \


### PR DESCRIPTION
This solves the following problem. It can be removed in the future if netifaces is no longer used as a dependency of the OpenStack SDK.

netifaces.c:1808:9: error: initialization of 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]