### PR TITLE
homer: use docker hub as source for renovate

### DIFF
--- a/.github/workflows/build-homer-container-image.yml
+++ b/.github/workflows/build-homer-container-image.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - v24.12.1  # renovate: datasource=github-releases depName=bastienwirtz/homer
+          - v24.12.1  # renovate: datasource=docker depName=b4bz/homer
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/homer/Containerfile
+++ b/homer/Containerfile
@@ -2,7 +2,7 @@
 
 # build stage
 FROM node:23-alpine AS build-stage
-ARG VERSION=v24.12.1  # renovate: datasource=github-releases depName=bastienwirtz/homer
+ARG VERSION=v24.12.1  # renovate: datasource=docker depName=b4bz/homer
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
This avoids wrong versions like in osism/container-images#627