### PR TITLE
Revert "openstackclient: use pyclean (#634)"

### DIFF
--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -56,7 +56,6 @@ RUN apk update --no-cache \
       /requirements.extra.txt \
     && apk del .build-deps \
     && openstack complete > /osc.bash_completion \
-    && pyclean /usr \
     && addgroup -g $GROUP_ID dragon \
     && adduser -D -u $USER_ID -G dragon dragon \
     && mkdir /configuration \

--- a/openstackclient/files/requirements.extra.txt
+++ b/openstackclient/files/requirements.extra.txt
@@ -1,4 +1,3 @@
 keystoneauth-oidc
 keystoneauth-websso
-pyclean
 setuptools


### PR DESCRIPTION
This reverts commit 9124746f779220e22f95d9854f1adfbc9006ceca.

Since we are currently installing per system and not running the CLI as root, the execution is very slow.