### PR TITLE
Cleanup release names in OSC builds

### DIFF
--- a/.github/workflows/build-openstackclient-container-image.yml
+++ b/.github/workflows/build-openstackclient-container-image.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - caracal
-          - dalmatian
-          - epoxy
+          - 2024.1
+          - 2024.2
+          - 2025.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-alpine
 
-ARG VERSION=caracal
+ARG VERSION=2024.1
 
 ARG USER_ID=45000
 ARG GROUP_ID=45000
@@ -28,11 +28,8 @@ RUN apk update --no-cache \
       openssl-dev \
       python3-dev \
       rust \
-    && if [ $VERSION = "epoxy" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; fi \
-    && if [ $VERSION = "dalmatian" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-2024.2.tar.gz; fi \
-    && if [ $VERSION = "caracal" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-2024.1.tar.gz; fi \
-    && if [ $VERSION = "bobcat" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-2023.2.tar.gz; fi \
-    && if [ $VERSION = "antelope" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-2023.1.tar.gz; fi \
+    && if [ $VERSION = 2025.1 ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; \
+       else wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
     && mkdir /requirements \
     && tar xzf /requirements.tar.gz -C /requirements --strip-components=1 \
     && rm -rf /requirements.tar.gz \

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -68,22 +68,7 @@ if [[ $IMAGE == "openstackclient" ]]; then
         docker push "$REPOSITORY:$version"
     fi
 
-    if [[ $VERSION == "antelope" ]]; then
-        docker tag "$REPOSITORY:$VERSION" "$REPOSITORY:2023.1"
-        docker push "$REPOSITORY:2023.1"
-    elif [[ $VERSION == "bobcat" ]]; then
-        docker tag "$REPOSITORY:$VERSION" "$REPOSITORY:2023.2"
-        docker push "$REPOSITORY:2023.2"
-    elif [[ $VERSION == "caracal" ]]; then
-        docker tag "$REPOSITORY:$VERSION" "$REPOSITORY:2024.1"
-        docker push "$REPOSITORY:2024.1"
-    elif [[ $VERSION == "dalmatian" ]]; then
-        docker tag "$REPOSITORY:$VERSION" "$REPOSITORY:2024.2"
-        docker push "$REPOSITORY:2024.2"
-    elif [[ $VERSION == "epoxy" ]]; then
-        docker tag "$REPOSITORY:$VERSION" "$REPOSITORY:2025.1"
-        docker push "$REPOSITORY:2025.1"
-    fi
+    docker push "$REPOSITORY:$VERSION"
 fi
 
 # push e.g. osism/ceph-daemon:12.2.13 + osism/ceph-daemon:pacific


### PR DESCRIPTION
Use the new version number everywhere in order to reduce confusion.