### PR TITLE
openstackclient: add xorriso

### DIFF
--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -30,6 +30,7 @@ RUN apk update --no-cache \
       openssl-dev \
       python3-dev \
       rust \
+      xorriso \
     && if [ $VERSION = "2025.2" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; else wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
     && mkdir /requirements \
     && tar xzf /requirements.tar.gz -C /requirements --strip-components=1 \


### PR DESCRIPTION
It is being used by the baremetal client in order to generate a config drive image when needed,