### PR TITLE
openstackclient: add --tries=3 to wget on tarballs.opendev.org

### DIFF
--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -31,7 +31,7 @@ RUN apk update --no-cache \
       openssl-dev \
       python3-dev \
       rust \
-    && if [ $VERSION = "2026.1" ]; then wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; else wget -q -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
+    && if [ $VERSION = "2026.1" ]; then wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; else wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
     && mkdir /requirements \
     && tar xzf /requirements.tar.gz -C /requirements --strip-components=1 \
     && rm -rf /requirements.tar.gz \


### PR DESCRIPTION
## Problem

\`tarballs.opendev.org\` is subject to transient DNS and connectivity
failures. The \`wget\` call in \`openstackclient/Containerfile\` downloads
the OpenStack requirements tarball from that host with no retry logic,
causing the build to fail immediately on any transient error.

Confirmed failures caused by this:

- [2026-03-13](https://github.com/osism/container-images/actions/runs/23035279269/job/66901814268): \`wget: can't connect to remote host (Connection refused)\` — 2025.2 matrix entry
- [2026-03-16](https://github.com/osism/container-images/actions/runs/23127364384/job/67173167955): \`wget: can't connect to remote host (Connection refused)\` — 2025.1 matrix entry

## Fix

Add \`--tries=3\` to both \`wget\` invocations (master tarball for
\`VERSION=2026.1\`, stable tarball for all other versions).

Note: the \`ping\`-based DNS warm-up used in the sibling shell script
fixes is not applicable here — ICMP is blocked in the \`docker buildx
build\` environment on GitHub Actions ubuntu-24.04 runners
([actions/runner-images#11614](https://github.com/actions/runner-images/issues/11614)).
\`wget\`'s own retry logic covers both DNS and connection failures.

This mirrors fixes already applied to the same host in sibling
repositories:
- [container-images-kolla#721](https://github.com/osism/container-images-kolla/pull/721) (\`scripts/003-patch.sh\`)
- [openstack-ironic-images#204](https://github.com/osism/openstack-ironic-images/pull/204) (\`elements/metalbox/install.d/40-install\`)