### PR TITLE
ansible-lint: fix osism-fqcn skip for blocks

### DIFF
--- a/ansible-lint/files/osism_fqcn.py
+++ b/ansible-lint/files/osism_fqcn.py
@@ -33,14 +33,12 @@ class OsismFQCNRule(AnsibleLintRule):
                 print(exception)
                 sys.exit(0)
 
-        # Skip validation for block, rescue, and always constructs
-        if "action" not in task or "__ansible_module_original__" not in task["action"]:
+        # block/rescue/always aren't real modules; ansible-lint sets their action to this fixed string
+        module = task["action"]["__ansible_module_original__"]
+        if module == "block/always/rescue":
             return False
 
         for category in osism_fqcn_list:
-            if (
-                task["action"]["__ansible_module_original__"]
-                in osism_fqcn_list[category]
-            ):
+            if module in osism_fqcn_list[category]:
                 return False
         return True


### PR DESCRIPTION
## Summary

The custom `osism-fqcn` ansible-lint rule checks every task's module
against an allowlist. The earlier "skip blocks" guard (#850) tested
whether the action dict lacked the `__ansible_module_original__` key —
but that test never matched: `block`/`rescue`/`always` constructs *do*
carry that key, set to the placeholder string `block/always/rescue`.

As a result every bare `block`/`rescue`/`always` fell through to the
allowlist check, was not found, and raised a spurious `osism-fqcn`
violation — which is why `# noqa: osism-fqcn` annotations have been
spreading across consuming repos.

This change detects blocks by the actual sentinel value instead of by
the presence of the key, and reads the module name once for reuse. It
also drops the redundant `"action" not in task` guard: `matchtask` is
always called with a normalized task that carries an `action`, and the
allowlist loop already dereferenced `task["action"]` unconditionally.
Keeping that guard only masked a broken assumption that should surface
as an error rather than silently passing the task.

## Verification

Reproduced against ansible-lint 26.4.0 (image pins 26.3.0):

- Before: a bare `block:` is flagged `osism-fqcn`.
- After: `block`/`rescue`/`always` pass; genuinely short (non-FQCN)
  module names inside them are still flagged.

## Follow-up

Once a new `ansible-lint` image is published with this fix, the now
unnecessary `# noqa: osism-fqcn` block annotations can be removed from
the consuming repos, and the stale vendored copies of the rule can be
synced. Tracked in osism/issues#1368.