### PR TITLE
ansible-lint: drop dead block allowlist entries

### DIFF
--- a/ansible-lint/files/osism_fqcn_list.yaml
+++ b/ansible-lint/files/osism_fqcn_list.yaml
@@ -496,10 +496,5 @@ other:
   - hashivault_auth_method
   - hashivault_policy
 
-ansible:
-  - always
-  - block
-  - rescue
-
 kolla:
   - kolla_toolbox


### PR DESCRIPTION
Removes the `ansible:` group (`always`, `block`, `rescue`) from the
osism-fqcn FQCN allowlist (`ansible-lint/files/osism_fqcn_list.yaml`).

## Why it's dead code

The rule represents a `block`/`rescue`/`always` construct with the
single combined action string `"block/always/rescue"`, which never
matches the bare `always`/`block`/`rescue` allowlist entries. That
mismatch was the original false-positive bug that forced `# noqa`
workarounds across many repos.

The fix in #902 (commit 5aea43c) handles these constructs with an
explicit early return in `osism_fqcn.py` when the module equals
`"block/always/rescue"`, before the allowlist is consulted. So the
`ansible:` group can never match — in either the old or new code path —
and is misleading, since it looks like the mechanism that exempts
blocks but isn't.

## Verification

Behavioural no-op. Ran the published `ansible-lint` image against a
probe playbook, comparing the built-in list vs. this modified list:

- a `block` construct is still **not** flagged by osism-fqcn
- a bare non-allowlisted module (`shell`) is still flagged

Output is identical with and without the `ansible:` group.

Follow-up cleanup to #902 / osism/issues#1368.

Related-Bug: #1368