### PR TITLE
openstackclient: drop 2024.2 from build matrix

### DIFF
--- a/.github/workflows/build-openstackclient-container-image.yml
+++ b/.github/workflows/build-openstackclient-container-image.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - "2024.2"
           - "2025.1"
           - "2025.2"
           - "2026.1"


### PR DESCRIPTION
## Summary

OpenStack 2024.2 Dalmatian reached EOL upstream on 2026-04-29. The `openstackclient` image is not part of the security-update delivery vehicle for sites still running 2024.2 (only the kolla service images and kolla-ansible keep building from the `2024.2-eol` tag), so its matrix entry is removed now.

This build does not fail at EOL — the requirements tarball it fetches outlives the deleted `stable/2024.2` branch — so the entry has to be removed proactively. See the [retirement guide](https://osism.tech/docs/guides/developer-guide/retiring-openstack-releases) (osism/osism.github.io#994).

The other 2024.2 matrix entries in this repository (`keystone-shib`, `cinder-volume-extra`, `cinder-volume-huawei`) are kolla-derived and follow the keep-building decision; they are out of scope here.

Part of the 2024.2 retirement:

- osism/issues#1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)