### PR TITLE
ara-server: bound the migration retry loop

### DIFF
--- a/ara-server/files/run.sh
+++ b/ara-server/files/run.sh
@@ -22,7 +22,22 @@ ARA_WORKERS=${ARA_WORKERS:-5}
 ARA_WORKER_CLASS=${ARA_WORKER_CLASS:-gevent}
 ARA_WORKER_CONNECTIONS=${ARA_WORKER_CONNECTIONS:-1000}
 
-until ara-manage migrate; do
+MIGRATION_ATTEMPTS=${ARA_MIGRATION_ATTEMPTS:-30}
+
+if ! [[ "$MIGRATION_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ARA_MIGRATION_ATTEMPTS must be a positive integer, got: '$MIGRATION_ATTEMPTS'"
+    exit 1
+fi
+
+for attempt in $(seq 1 "$MIGRATION_ATTEMPTS"); do
+    if ara-manage migrate; then
+        break
+    fi
+    if [[ "$attempt" == "$MIGRATION_ATTEMPTS" ]]; then
+        echo "database migration failed after $MIGRATION_ATTEMPTS attempts"
+        echo "ARA server will not start; inspect ara-manage migrate output"
+        exit 1
+    fi
     echo "database migration failed, trying again in 10 seconds"
     sleep 10
 done


### PR DESCRIPTION
## What

The ara-server entrypoint (`ara-server/files/run.sh`) retried `ara-manage migrate` in an unbounded `until` loop. On a permanent migration failure this spins forever: the schema never migrates, gunicorn never starts, and the container stays up reporting healthy, so the failure is silent.

This replaces the loop with a bounded one:

- Retry up to `ARA_MIGRATION_ATTEMPTS` times (default `30`, ~5 min at 10 s spacing).
- On the final failure, print a clear diagnostic and `exit 1`, so compose/systemd report a failed container.
- Validate `ARA_MIGRATION_ATTEMPTS` up front: a non-positive or non-numeric value would make `seq 1 N` yield no iterations, silently skipping the migration and starting gunicorn against an unmigrated DB. Anything that is not a positive integer is rejected with `exit 1`.
- The entrypoint never touches or deletes the database — its only new job is to make a permanent failure explicit.

## Why

This is Part 1 of a fix for the ARA server upgrade path on populated pre-1.7.4 MariaDB, where migration `0018` fails permanently and the old unbounded loop hid it. It stands alone as a generic safety net (also covers the SQLite/tmpfs paths) and is independent of the companion Ansible-side reset guard landing in `osism/ansible-collection-services`.

## Testing

- `bash -n` passes; no new shellcheck findings (pre-existing SC2086 infos on the gunicorn lines only).
- Loop logic verified in isolation: always-failing migrate exits `1` after exactly N attempts (no infinite loop); success breaks to the post-migration path with exit `0`.
- Validation verified: `0`, negatives, non-numeric, empty, and leading-zero values are rejected; positive integers accepted.