### PR TITLE
ara-server: preserve ARA history on 0018 upgrade

### DIFF
--- a/ara-server/Containerfile
+++ b/ara-server/Containerfile
@@ -37,6 +37,21 @@ RUN apt-get update \
     && useradd ara-server \
     && rm -rf /var/lib/apt/lists/* /wheels /requirements.txt
 
+COPY files/migrations/0018_alter_play_uuid_alter_task_uuid.py /tmp/0018-patched.py
+
+# Replace ARA's stock migration 0018 with the OSISM history-preserving version.
+# Assert the stock file's sha256 first so a future ARA release that changes 0018
+# fails the build (drift guard) instead of silently shipping a stale patch.
+# When the build fails here after an ARA bump: review the new upstream 0018,
+# confirm the patched migration still applies, then update the pinned sha256.
+RUN set -eu; \
+    MIG_DIR="$(python3 -c 'import ara.api.migrations, os; print(os.path.dirname(ara.api.migrations.__file__))')"; \
+    STOCK="$MIG_DIR/0018_alter_play_uuid_alter_task_uuid.py"; \
+    test -f "$STOCK"; \
+    echo "e5150237e6c0678f44d335009af6bab8c2b488e9fd5224ee6ac34dbdae439004  $STOCK" | sha256sum -c -; \
+    cp /tmp/0018-patched.py "$STOCK"; \
+    rm /tmp/0018-patched.py
+
 USER ara-server
 WORKDIR /home/ara-server
 

--- a/ara-server/files/migrations/0018_alter_play_uuid_alter_task_uuid.py
+++ b/ara-server/files/migrations/0018_alter_play_uuid_alter_task_uuid.py
@@ -1,0 +1,50 @@
+# OSISM downstream replacement for ARA's stock migration 0018.
+#
+# Stock 0018 issues a bare `ALTER TABLE ... MODIFY uuid char(32)`, which fails on
+# a populated MariaDB whose plays.uuid/tasks.uuid are native `uuid` columns: the
+# 36-char dashed render overflows char(32) -> DataError 1406. This version
+# normalizes the existing MariaDB data in place before the column shrinks, so ARA
+# history is preserved. On a fresh DB and on non-MySQL backends it is
+# behavior-identical to stock. Background: ARA issues #617 and #628
+# (https://codeberg.org/ansible-community/ara/issues/628).
+from django.db import migrations
+import ara.api.models
+
+
+def normalize_mysql_uuids(apps, schema_editor):
+    # Only MariaDB/MySQL stored pre-1.7.4 UUIDs as native `uuid` columns.
+    if schema_editor.connection.vendor != "mysql":
+        return
+    quote = schema_editor.quote_name
+    play = quote(apps.get_model("api", "Play")._meta.db_table)
+    task = quote(apps.get_model("api", "Task")._meta.db_table)
+    col = quote("uuid")
+    with schema_editor.connection.cursor() as cursor:
+        # widen native uuid -> char(36) so the dashed render fits, then de-dash
+        cursor.execute(f"ALTER TABLE {play} MODIFY {col} char(36) NOT NULL")
+        cursor.execute(f"UPDATE {play} SET {col} = REPLACE({col}, '-', '')")
+        cursor.execute(f"ALTER TABLE {task} MODIFY {col} char(36) NULL")
+        cursor.execute(f"UPDATE {task} SET {col} = REPLACE({col}, '-', '') WHERE {col} IS NOT NULL")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0017_optional_playbook_controller"),
+    ]
+
+    operations = [
+        # Reverse is intentionally a no-op: the forward de-dash is not re-applied
+        # on rollback (these ARA migrations are forward-only in practice).
+        migrations.RunPython(normalize_mysql_uuids, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="play",
+            name="uuid",
+            field=ara.api.models.Char32UUIDField(),
+        ),
+        migrations.AlterField(
+            model_name="task",
+            name="uuid",
+            field=ara.api.models.Char32UUIDField(null=True),
+        ),
+    ]


### PR DESCRIPTION
## Problem

Upgrading the bundled ARA server from a pre-1.7.4 image to 1.7.4+ on a deployment whose ARA MariaDB is **already populated** wedges. ARA 1.7.4 ships migration `0018_alter_play_uuid_alter_task_uuid`, which issues a bare `ALTER TABLE ... MODIFY uuid char(32)`. On databases created under Django 5.0+, `plays.uuid` / `tasks.uuid` are MariaDB **native `uuid`** columns; MariaDB renders those to the 36-char dashed form, which overflows `char(32)` → `DataError (1406, "Data too long for column 'uuid'")`. The entrypoint retries `ara-manage migrate` forever, so the schema never migrates and gunicorn never starts.

## Change

A downstream-corrected `0018` that **preserves ARA history** by normalizing the existing data in place instead of failing:

- For **MySQL/MariaDB only**, widen the columns to `char(36)`, strip dashes with `REPLACE`, then the existing `AlterField` ops shrink to `char(32)`. Existing rows fit; no 1406.
- On a **fresh DB and on PostgreSQL/SQLite** the migration is behavior-identical to stock: the data step early-returns on non-MySQL, and the `AlterField` operations (and resulting Django state → `Char32UUIDField`) are unchanged.
- The image installs the patched file over the pip-installed stock `0018`, guarded by a **pinned sha256 of the stock file** — a future ARA release that changes `0018` fails the build (drift guard) rather than silently shipping a stale patch.

## Validation

An end-to-end harness reproduced the broken native-`uuid` state and ran the real upgrade with the locally built image:

- migrate exits 0, `0018` recorded, **row counts preserved**, every `uuid` equals its de-dashed baseline, both columns end `char(32)`, `GET /api/v1/plays` serves the history.
- Verified at small (3+3 rows) and **scale (50,003 + 50,003 rows, migrate ~18s)**.
- Build verified: builds against ARA 1.7.5 with the pinned hash matching; the patched migration is present in the image; a deliberately wrong pinned hash fails the build.

## Notes

- Complementary to — not a replacement for — the bounded migration-retry change; the two should land together for correct startup behavior:
  - #928
- The data fix is backend-correct and not OSISM-specific, so it is a candidate to propose **upstream to ARA** (background: <https://codeberg.org/ansible-community/ara/issues/617>, <https://codeberg.org/ansible-community/ara/issues/628>).
- Draft: opened as a candidate history-preserving approach for discussion.

Assisted-by: Claude:claude-opus-4-8