### PR TITLE
fix: pin CycloneDX spec version to 1.6 for SBOM upload

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -22,7 +22,7 @@ generate_sbom() {
     local repository="$1"
     local version="$2"
 
-    /usr/local/bin/syft scan "$repository:$version" -o cyclonedx-json > sbom.json
+    /usr/local/bin/syft scan "$repository:$version" -o cyclonedx-json@1.6 > sbom.json
     dtrackauditor \
       -p $(basename $repository) \
       -v "$version" \


### PR DESCRIPTION
## Problem

The SBOM upload to DependencyTrack fails with:

```
HTTP-400 Bad Request => {"status":400,"title":"The uploaded BOM is invalid","detail":"Unrecognized specVersion 1.7"}
```

`syft` is installed unpinned (`latest`) and now defaults to emitting CycloneDX **specVersion 1.7**. DependencyTrack does not yet support 1.7 and rejects the upload.

## Fix

Pin the syft output format to `cyclonedx-json@1.6`, the highest CycloneDX spec version DependencyTrack currently accepts. This makes the SBOM upload independent of syft's evolving default.

Same fix as:

- osism/container-image-osism-ansible#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)