### PR TITLE
seed: bake ansible.cfg disabling host key checking

### DIFF
--- a/seed/Containerfile
+++ b/seed/Containerfile
@@ -3,6 +3,7 @@ FROM python:${PYTHON_VERSION}-alpine
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.22 /uv /usr/local/bin/uv
 
+COPY files/ansible.cfg /etc/ansible/ansible.cfg
 COPY files/requirements.txt /requirements.txt
 COPY files/requirements.yml /requirements.yml
 COPY files/releases.txt /releases.txt

--- a/seed/files/ansible.cfg
+++ b/seed/files/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+host_key_checking = false
+
+[ssh_connection]
+pipelining = true


### PR DESCRIPTION
## Problem

The `osism/seed` image ships no `ansible.cfg`, so Ansible inside it falls back to its built-in default `host_key_checking = True`.

The new `osism update manager` seed-container path (wired in `ansible-collection-services` `f1e7869f`) runs `osism.manager.manager` from this image via `ansible-playbook -i hosts`, with the working directory at `/opt/configuration/environments/manager`. Host-key trust there depends entirely on an `ansible.cfg` in that directory.

On a seed-deployed manager whose configuration repository ships no `environments/manager/ansible.cfg` (e.g. the testbed), nothing turns host-key checking off. So `Apply role manager`'s first SSH to the manager runs strict checking against an empty `known_hosts` and aborts with `Host key verification failed`, breaking `testbed-update` at the final re-apply:

```
fatal: [testbed-manager]: UNREACHABLE! => {"changed": false,
  "msg": "Failed to connect to the host via ssh: Host key
  verification failed.", "unreachable": true}
```

Deploy-time manager apply does not hit this because it runs from the `osism-ansible` image, which already bakes `host_key_checking = false`.

## Fix

Bake a minimal `ansible.cfg` into the seed image at `/etc/ansible/ansible.cfg`, reaching parity with the `osism-ansible` image (`host_key_checking = false`, `pipelining = true`).

`/etc/ansible` is the lowest-precedence config location, so a per-config `environments/manager/ansible.cfg` in the working directory still overrides it.

## Notes

- Takes effect once `osism/seed:latest` is rebuilt/released.
- Defense-in-depth for any config missing the file. The testbed-side fix that adds the missing `environments/manager/ansible.cfg` overlay is osism/testbed#2916.
- First observed in periodic-midnight build `b842f678` on 2026-06-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)