### PR TITLE
tempest: restore hosts disabled by affinity test

### DIFF
--- a/tempest/Containerfile
+++ b/tempest/Containerfile
@@ -25,6 +25,7 @@ ARG GROUP_ID=45000
 COPY --link --from=gobuild --chmod=0755 /opt/octavia-tempest-plugin/test_server.bin /opt/octavia-tempest-plugin/test_server.bin
 COPY --link files/requirements.txt /requirements.txt
 COPY --link files/upper-constraints.txt /upper-constraints.txt
+COPY --link files/patches/ /patches/
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,21 +42,34 @@ apt-get update
 apt-get install --no-install-recommends -y \
   build-essential \
   iputils-ping \
-  openssh-client
+  openssh-client \
+  patch
 python3 -m pip install --no-cache-dir --upgrade 'pip==26.1.2'
 pip3 install --no-cache-dir -r /requirements.txt -c /upper-constraints.txt
+
+# Apply OSISM-local tempest patches (files/patches/*.patch). Dry-run first so
+# the build fails loudly if a patch no longer applies -- e.g. once
+# requirements.txt bumps tempest to a release that fixed the bug upstream, at
+# which point the stale patch must be deleted (self-expiring, OSISM P5).
+SITE_PACKAGES=$(python3 -c 'import tempest, os; print(os.path.dirname(os.path.dirname(tempest.__file__)))')
+for p in /patches/*.patch; do
+  echo "APPLY PATCH $p"
+  patch -p1 -d "$SITE_PACKAGES" --forward --batch --dry-run < "$p"
+  patch -p1 -d "$SITE_PACKAGES" --forward --batch < "$p"
+done
 
 # add user
 groupadd -g "$GROUP_ID" dragon
 useradd -l -g dragon -u "$USER_ID" -m -d /home/dragon dragon
 
 # cleanup
-apt-get remove -y build-essential
+apt-get remove -y build-essential patch
 apt-get autoremove -y
 apt-get clean
 rm -rf \
   /var/lib/apt/lists/* \
   /var/tmp/* \
+  /patches \
   /requirements.txt
 
 pip3 install --no-cache-dir pyclean==3.0.0

--- a/tempest/files/patches/0001-server-affinity-restore-disabled-hosts.patch
+++ b/tempest/files/patches/0001-server-affinity-restore-disabled-hosts.patch
@@ -1,0 +1,46 @@
+Subject: [PATCH] serial_tests: restore compute hosts disabled by affinity setup
+
+ServersAffinityTest.resource_setup() disables all-but-two nova-compute
+services to build a controlled scheduling environment, but never
+re-enables them. There is no resource_cleanup()/addClassResourceCleanup()
+for the setup-disabled hosts (the only re-enable is the per-test
+_disable_compute_host() addCleanup), so every run of this class leaks a
+permanently-disabled compute service.
+
+On a 3-compute cloud this leaves exactly one host disabled after the class
+finishes. That silently breaks any workload needing all hosts -- notably
+Octavia ACTIVE_STANDBY + anti-affinity load balancer failover, which needs
+a third enabled host to place the replacement amphora and otherwise fails
+with NoValidHost.
+
+The bug is present on tempest master as of 46.3.0; no upstream fix exists
+yet. Register a class-teardown cleanup that re-enables each host this setup
+disabled, preserving the test's coverage. The setup now also skips hosts
+that were already disabled (e.g. for maintenance) rather than disabling and
+then unconditionally re-enabling them -- it restores only the state it
+changed, so a maintenance-disabled compute is never brought back into
+scheduling.
+
+Self-expiring: this patch is applied by the tempest image build with
+`patch --forward --dry-run` gating. When requirements.txt bumps tempest to
+a release that fixes this upstream, the patch will no longer apply, the
+build will fail, and this file must be deleted.
+
+--- a/tempest/serial_tests/api/compute/admin/test_server_affinity.py
++++ b/tempest/serial_tests/api/compute/admin/test_server_affinity.py
+@@ -46,8 +46,16 @@ class ServersAffinityTest(base.BaseV2ComputeAdminTest):
+         num_extra = len(services) - 2
+         for i in range(num_extra):
+             service = services.pop()
++            if service['status'] != 'enabled':
++                # Leave an already-disabled host (e.g. under
++                # maintenance) untouched; restore only what this
++                # setup disabled.
++                continue
+             cls.os_admin.services_client.update_service(
+                 service['id'], status='disabled')
++            cls.addClassResourceCleanup(
++                cls.os_admin.services_client.update_service,
++                service['id'], status='enabled')
+         cls.services = {
+             service['host']: service['id'] for service in services}


### PR DESCRIPTION
## What

Add a patch step to the tempest image build (`files/patches/*.patch` applied
after the pip install, `patch --forward --dry-run` gated) and a first patch
fixing an unfixed-upstream tempest bug.

## Why

`ServersAffinityTest.resource_setup()` disables all-but-two nova-compute
services to build a controlled scheduling environment, but never re-enables
them: there is no `resource_cleanup`/`addClassResourceCleanup` for the
setup-disabled hosts (the only re-enable is the per-test
`_disable_compute_host` `addCleanup`). Every run of this class therefore leaks
a permanently-disabled compute service.

On a three-compute cloud it leaves exactly one host disabled after the class
finishes, which silently breaks workloads that need all hosts — notably
Octavia `ACTIVE_STANDBY` + anti-affinity load balancer failover, which needs a
third enabled host for the replacement amphora and otherwise fails with
`NoValidHost`.

The bug is present on tempest master as of 46.3.0; no upstream fix exists yet.

## How

The patch adds a class-teardown cleanup (`addClassResourceCleanup`) that
re-enables each host this setup disabled, preserving the test's coverage.

It also skips hosts that were **already** disabled (e.g. for maintenance)
instead of disabling and then unconditionally re-enabling them — the setup
restores only the state it changed and never brings a maintenance-disabled
compute back into scheduling.

The patch step is **self-expiring**: applied with `patch --forward --dry-run`
first, so when `requirements.txt` bumps tempest to a release that fixes this
upstream the patch stops applying, the build fails, and the stale patch must be
deleted.

## Validation

Built the patched image and ran the full `ServersAffinityTest` class serially
against it: **7/7 passed**, and **all three nova-compute hosts stayed enabled**
afterward (baseline was three enabled; the unpatched class leaves one disabled).

## Follow-up

- [ ] File the upstream tempest bug (this patch is a local carry until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)