### PR TITLE
openstackclient: publish a rolling :latest tag

### DIFF
--- a/.github/workflows/build-openstackclient-container-image.yml
+++ b/.github/workflows/build-openstackclient-container-image.yml
@@ -22,10 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version:
-          - "2025.1"
-          - "2025.2"
-          - "2026.1"
+        # Mark the rolling series (built from OpenStack master) with
+        # rolling: "true". It is the single source of truth: it selects the
+        # master requirements in the build (ROLLING build-arg) and publishes the
+        # image as :latest (PUBLISH_LATEST). Move this flag when the rolling
+        # series advances (e.g. to a future 2026.2 entry).
+        include:
+          - version: "2025.1"
+          - version: "2025.2"
+          - version: "2026.1"
+            rolling: "true"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -51,6 +57,7 @@ jobs:
           IMAGE: openstackclient
           REPOSITORY: osism/openstackclient
           VERSION: ${{ matrix.version }}
+          ROLLING: ${{ matrix.rolling }}
 
       - name: Push container image
         run: |
@@ -66,6 +73,7 @@ jobs:
           IMAGE: openstackclient
           REPOSITORY: osism/openstackclient
           VERSION: ${{ matrix.version }}
+          PUBLISH_LATEST: ${{ matrix.rolling }}
         if: |
           github.repository == 'osism/container-images' &&
           github.ref == 'refs/heads/main'

--- a/openstackclient/Containerfile
+++ b/openstackclient/Containerfile
@@ -3,6 +3,11 @@ FROM python:${PYTHON_VERSION}-alpine
 
 ARG VERSION=2026.1
 
+# ROLLING=true selects the OpenStack master requirements below; the build
+# matrix sets it for the rolling series. Otherwise the stable-series
+# upper-constraints for VERSION are used.
+ARG ROLLING=false
+
 ARG USER_ID=45000
 ARG GROUP_ID=45000
 
@@ -31,7 +36,7 @@ RUN apk update --no-cache \
       openssl-dev \
       python3-dev \
       rust \
-    && if [ $VERSION = "2026.1" ]; then wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; else wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
+    && if [ "$ROLLING" = "true" ]; then wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-master.tar.gz; else wget -q --tries=3 -P / -O requirements.tar.gz https://tarballs.opendev.org/openstack/requirements/requirements-stable-${VERSION}.tar.gz; fi \
     && mkdir /requirements \
     && tar xzf /requirements.tar.gz -C /requirements --strip-components=1 \
     && rm -rf /requirements.tar.gz \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,6 +55,9 @@ elif [[ $IMAGE == "openstackclient" ]]; then
 	PYTHON_VERSION=3.13
     fi
     BUILD_OPTS="$BUILD_OPTS --build-arg PYTHON_VERSION=$PYTHON_VERSION"
+    # ROLLING (set by the build matrix for the rolling series) selects the
+    # OpenStack master requirements in the Containerfile.
+    BUILD_OPTS="$BUILD_OPTS --build-arg ROLLING=${ROLLING:-false}"
 fi
 
 docker buildx build \

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -129,6 +129,19 @@ if [[ $IMAGE == "openstackclient" ]]; then
     docker push "$REPOSITORY:$VERSION"
     generate_sbom $REPOSITORY $VERSION
     sign_image $REPOSITORY $VERSION
+
+    # Publish :latest for the rolling/newest build. The workflow marks that
+    # matrix entry with PUBLISH_LATEST=true rather than hardcoding a series
+    # number here, so this stays correct when the rolling series advances
+    # (2026.1 -> 2026.2 -> ...). "openstack_version: latest" deployments then
+    # resolve to this client, matching the other OpenStack components (whose
+    # :latest is the master build).
+    if [[ "${PUBLISH_LATEST:-false}" == "true" ]]; then
+        docker tag "$REPOSITORY:$REVISION" "$REPOSITORY:latest"
+        docker push "$REPOSITORY:latest"
+        generate_sbom $REPOSITORY latest
+        sign_image $REPOSITORY latest
+    fi
 fi
 
 # push e.g. osism/ceph-daemon:12.2.13 + osism/ceph-daemon:pacific


### PR DESCRIPTION
## Problem

`osism/openstackclient` is published **per-series only** (`2025.1`/`2025.2`/`2026.1`), with **no `:latest`** — unlike sibling images in `push.sh` (`ara-server`/`netbox`/`pulp`) and unlike the OpenStack **components**, whose `:latest` is the master build. So an `openstack_version: latest` (rolling) deployment resolves the client tag to `openstackclient:latest`, which does not exist → the pull fails, while `keystone:latest` etc. resolve.

## Fix — publish `:latest` from the rolling build, with one source of truth

Publish the rolling (master-based) build additionally as `:latest`, and make the **build matrix** the single source of truth for which series is rolling:

- the matrix marks that entry with `rolling: "true"`;
- it drives the **build** (`ROLLING` build-arg → the Containerfile selects `requirements-master`, replacing the previous hardcoded `VERSION == "2026.1"` check);
- it drives the **push** (`PUBLISH_LATEST` → `push.sh` also tags `:latest`).

Advancing the rolling series (`2026.1 → 2026.2 → …`) is then a **single edit** — move `rolling: "true"` in the matrix — with no change to `push.sh`, `build.sh`, or the Containerfile.

Result: `openstackclient:latest` = the rolling (master-based) client, consistent with the master-based component images.

## Companion change

This is the image-side half. The deploy-side half:

- osism/ansible-collection-services#2135 — makes the openstackclient/cephclient role defaults track `openstack_version`/`ceph_version` so the client follows the configured series (concrete series works today; the `latest` selection resolves once this PR publishes the tag).