### PR TITLE
tempest: fix octavia barbican-TLS scenario tests

### DIFF
--- a/tempest/files/patches/0002-octavia-cert-utils-aki.patch
+++ b/tempest/files/patches/0002-octavia-cert-utils-aki.patch
@@ -1,0 +1,62 @@
+Subject: [PATCH] cert_utils: add SubjectKeyIdentifier/AuthorityKeyIdentifier
+
+octavia_tempest_plugin's test cert fixtures build a CA (generate_ca_cert_and_key)
+without a SubjectKeyIdentifier and leaf server/client certs
+(generate_server_cert_and_key / generate_client_cert_and_key) without an
+AuthorityKeyIdentifier. RFC 5280 says both SHOULD be present, and the strict
+X.509 verification now enabled by default in newer OpenSSL / Python ssl rejects
+the chain outright:
+
+    [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
+    Missing Authority Key Identifier
+
+The barbican TLS scenario tests (test_tls_barbican) upload one of these certs to
+Barbican, drive an Octavia TLS-terminating listener with it, then connect back
+with an httpx client that verifies against the test CA -- so every
+test_http_*_tls_traffic case fails at connect time even though Octavia itself is
+healthy (its own amphora/server/client CAs already carry SKI+AKI).
+
+Add the standard key-identifier pair: SubjectKeyIdentifier on the CA and a
+matching AuthorityKeyIdentifier (derived from the issuer public key) on the
+server and client leaf certs. Both use RFC 5280 method-1 (SHA1 of the public
+key), so the leaf AKI keyid matches the CA SKI keyid and the chain builds.
+
+Self-expiring: applied by the tempest image build with `patch --forward
+--dry-run` gating. When octavia-tempest-plugin ships this upstream and the pin
+bumps past it, the patch will no longer apply, the build will fail, and this
+file must be deleted.
+
+--- a/octavia_tempest_plugin/common/cert_utils.py
++++ b/octavia_tempest_plugin/common/cert_utils.py
+@@ -66,6 +66,9 @@ def generate_ca_cert_and_key():
+         x509.KeyUsage(True, False, False, False, False,
+                       True, True, False, False),
+         critical=True,
++    ).add_extension(
++        x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
++        critical=False,
+     ).sign(ca_key, hashes.SHA256(), default_backend())
+
+     return ca_cert, ca_key
+@@ -119,6 +122,10 @@ def generate_server_cert_and_key(ca_cert, ca_key, server_uuid):
+         x509.KeyUsage(True, False, True, False, False,
+                       False, False, False, False),
+         critical=True,
++    ).add_extension(
++        x509.AuthorityKeyIdentifier.from_issuer_public_key(
++            ca_key.public_key()),
++        critical=False,
+     ).sign(ca_key, hashes.SHA256(), default_backend())
+
+     return server_cert, server_key
+@@ -167,6 +174,10 @@ def generate_client_cert_and_key(ca_cert, ca_key, client_uuid):
+         x509.KeyUsage(True, True, True, False, False, False,
+                       False, False, False),
+         critical=True,
++    ).add_extension(
++        x509.AuthorityKeyIdentifier.from_issuer_public_key(
++            ca_key.public_key()),
++        critical=False,
+     ).sign(ca_key, hashes.SHA256(), default_backend())
+
+     return client_cert, client_key

--- a/tempest/files/patches/0003-octavia-tls-traffic-connect-retry.patch
+++ b/tempest/files/patches/0003-octavia-tls-traffic-connect-retry.patch
@@ -1,0 +1,57 @@
+Subject: [PATCH] test_tls_barbican: retry the initial TLS traffic connect
+
+octavia_tempest_plugin's _test_http_versions_tls_traffic (the backing method for
+test_http_1_1_tls_traffic / test_http_2_tls_traffic / test_http_1_1_tls_hsts_traffic)
+waits for the load balancer to report ACTIVE and then does a single, unretried
+httpx client.get() against the VIP. On a slow or loaded deployment the VIP
+dataplane can lag the ACTIVE status by several seconds (security-group
+programming, HAProxy bind, gratuitous ARP), so the single connect trips httpx's
+default 5s connect timeout and the test fails with httpx.ConnectTimeout even
+though the listener is healthy. The sibling traffic tests don't see this because
+they go through the plugin's validate_URL_response helper, which already retries
+the request until CONF.load_balancer.build_timeout; only this httpx path (used so
+the test can assert the negotiated HTTP version, which the requests-based helper
+cannot) does a bare get.
+
+Mirror that retry behaviour on the httpx path: retry the initial connect on
+httpx.TransportError until the VIP accepts a connection, then run the existing
+HTTP-version / HSTS assertions unchanged.
+
+Self-expiring: applied by the tempest image build with `patch --forward
+--dry-run` gating. When octavia-tempest-plugin makes this connect robust upstream
+and the pin bumps past it, the patch will no longer apply, the build will fail,
+and this file must be deleted.
+
+--- a/octavia_tempest_plugin/tests/barbican_scenario/v2/test_tls_barbican.py
++++ b/octavia_tempest_plugin/tests/barbican_scenario/v2/test_tls_barbican.py
+@@ -17,6 +17,7 @@
+ import socket
+ import ssl
+ import tempfile
++import time
+
+ from cryptography.hazmat.primitives import serialization
+ import httpx
+@@ -1268,7 +1269,21 @@
+             client_kwargs['http1'] = False
+             client_kwargs['http2'] = True
+         client = httpx.Client(**client_kwargs)
+-        r = client.get(url)
++        # A freshly built load balancer can report ACTIVE a few seconds
++        # before its VIP dataplane accepts connections (security-group
++        # programming, HAProxy bind, gratuitous ARP). Retry the initial
++        # connect until the VIP is reachable, like the plugin's
++        # validate_URL_response helper, rather than failing on a single
++        # httpx.ConnectTimeout.
++        start = time.time()
++        while True:
++            try:
++                r = client.get(url)
++                break
++            except httpx.TransportError:
++                if time.time() - start >= CONF.load_balancer.build_timeout:
++                    raise
++                time.sleep(CONF.load_balancer.build_interval)
+         self.assertEqual(http_version, r.http_version)
+         if hsts:
+             self.assertIn('strict-transport-security', r.headers)


### PR DESCRIPTION
## What

Two self-expiring patches (same mechanism/gating as the affinity patch #945) that
make the octavia **barbican-TLS scenario** tests (`test_tls_barbican`) pass on this
image:

- `0002-octavia-cert-utils-aki.patch` — a latent octavia-tempest-plugin cert-fixture
  bug that Python 3.13 surfaces (the TLS traffic tests failed at cert verification).
- `0003-octavia-tls-traffic-connect-retry.patch` — a fragile single-connect in the
  same tests that flakes on slower deployments (the tests failed at TCP connect).

---

## Patch 0002 — cert AKI/SKI

`octavia_tempest_plugin/common/cert_utils.py` builds its test CA without a
`SubjectKeyIdentifier` and the leaf server/client certs without an
`AuthorityKeyIdentifier`. RFC 5280 says both SHOULD be present, but under
**non-strict** X.509 verification — the historical default — OpenSSL never checks
for them, so the chain verifies and the tests pass.

**Why it fails here but not upstream:** Python 3.13's `ssl.create_default_context()`
enables `VERIFY_X509_STRICT` by default. This image ships Python 3.13, and the
barbican TLS scenario tests connect back to the load balancer with `httpx`, which
builds its TLS context from that default — so the client now does strict
verification and rejects the fixture chain:

```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier
```

The OpenStack gate runs on distro Python (3.10/3.12), where `create_default_context()`
does not set `X509_STRICT`, so it never sees this. Octavia itself is unaffected: its
own amphora/server/client CAs already carry SKI+AKI.

**Fix:** add a `SubjectKeyIdentifier` on the CA and a matching
`AuthorityKeyIdentifier` (derived from the issuer public key) on the server and
client leaf certs, using RFC 5280 method 1 (SHA1 of the public key) so the leaf AKI
keyid matches the CA SKI keyid and the chain builds. RFC-compliant fix, not a
workaround.

---

## Patch 0003 — TLS traffic connect retry

`_test_http_versions_tls_traffic` (backing `test_http_1_1_tls_traffic` /
`test_http_2_tls_traffic` / `test_http_1_1_tls_hsts_traffic`) waits for the load
balancer to report ACTIVE and then does a **single, unretried** `httpx client.get()`
against the VIP. On a slow or loaded deployment the VIP dataplane can lag the ACTIVE
status by a few seconds (security-group programming, HAProxy bind, gratuitous ARP),
so the single connect trips httpx's default 5s connect timeout and the test fails
with `httpx.ConnectTimeout` even though the listener is healthy.

The sibling traffic tests don't hit this because they go through the plugin's
`validate_URL_response` helper, which already retries the request until
`CONF.load_balancer.build_timeout`; only this httpx path (used so the test can
assert the negotiated HTTP version, which the `requests`-based helper cannot) does a
bare get.

**Fix:** retry the initial connect on `httpx.TransportError` until the VIP accepts a
connection, mirroring `validate_URL_response`, then run the existing HTTP-version /
HSTS assertions unchanged.

---

## Verification

Built a local image (base + both patches applied through the build's `patch -p1
--forward` gate) and ran the barbican TLS tests through the tempest role on a live
full-profile 3-node cluster:

- `openssl verify -x509_strict` on regenerated fixtures: `error 85 Missing Authority
  Key Identifier` → **OK** (0002)
- `test_http_1_1_tls_traffic`, `test_http_2_tls_traffic`, and
  `test_http_1_1_tls_hsts_traffic` → **3/3 pass** (0002 clears the cert check; 0003
  clears the connect timeout — the HSTS case previously failed ~100% of the time)

Root-cause detail for the connect timeout: it is fresh-amphora dataplane lag on a
constrained testbed (verified directly — the amphora binds :443 and serves HSTS
correctly; a settled LB does hundreds of connects in a few ms), and it is **not**
HSTS-specific — the non-HSTS sibling times out identically when run standalone. It
only looked HSTS-specific because in a full run the test class shares an
already-settled load balancer, so whichever case happens to land in the settle
window is the one that reds.

## Notes

- Both are self-expiring (OSISM P5): once octavia-tempest-plugin ships these fixes
  upstream and the pin bumps past them, the `--dry-run` gate fails the build and the
  stale patch file must be deleted.
- Sibling of the same-mechanism patch:
  - osism/container-images#945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
