### PR TITLE
ansible-lint: resolve bare kolla-ansible modules

### DIFF
--- a/ansible-lint/Containerfile
+++ b/ansible-lint/Containerfile
@@ -5,7 +5,14 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.22 /uv /usr/local/bin/uv
 COPY files/rules/ /opt/osism/ansible-lint-rules/
 COPY files/run.sh files/prepare-config.py files/ansible-lint.yml \
      files/requirements.txt files/requirements.yml /
-ENV XDG_CACHE_HOME=/tmp/cache
+# Expose kolla-ansible's kolla_toolbox module so ansible-lint can resolve the bare
+# module reference in playbooks that call it (it is not packaged as a collection).
+# Re-fetched on every build, so no vendored copy drifts. Only kolla_toolbox is copied:
+# it is self-contained, whereas e.g. kolla_container imports helpers from kolla-ansible's
+# ansible/module_utils, which are not on the import path here and would make ansible-lint's
+# args rule fail on import rather than validate the task.
+ENV XDG_CACHE_HOME=/tmp/cache \
+    ANSIBLE_LIBRARY=/opt/osism/ansible-lint-library
 
 RUN apk add --no-cache --virtual .build-deps \
       build-base \
@@ -14,6 +21,10 @@ RUN apk add --no-cache --virtual .build-deps \
     && ansible-galaxy collection install -r /requirements.yml \
     && ansible-galaxy role install -r /requirements.yml \
     && mkdir -p /zuul \
+    && git clone --depth 1 https://github.com/openstack/kolla-ansible /tmp/kolla-ansible \
+    && mkdir -p /opt/osism/ansible-lint-library \
+    && cp /tmp/kolla-ansible/ansible/library/kolla_toolbox.py /opt/osism/ansible-lint-library/ \
+    && rm -rf /tmp/kolla-ansible \
     && apk del .build-deps \
     && uv pip install --no-cache --system pyclean==3.0.0 \
     && pyclean /usr \


### PR DESCRIPTION
Expose kolla-ansible's `kolla_toolbox` module to ansible-lint so this bare,
runtime-provided module resolves in the syntax-check phase. Only `kolla_toolbox`
is copied (not the whole `ansible/library/*.py` set): it is the only module OSISM
playbooks reference and it is self-contained, whereas modules like `kolla_container`
pull in kolla-ansible's `ansible/module_utils` helpers that are not importable here.
See the commit message for the full what/why/how.

## Verification

Full from-scratch build of the edited Containerfile, run against
`container-image-kolla-ansible`:

- fix branch (with the `container_engine` arg added) → lint passes clean.
- unfixed `main` → lint now correctly reports the missing `container_engine` arg,
  i.e. the image also catches upstream argument drift.

## Note for reviewers

The default branch (`master`) of kolla-ansible is cloned. It can be pinned to a
stable branch later to reduce noise if master churn causes false positives.

## Related

- osism/issues#1412
- osism/container-image-kolla-ansible#931 — the `container_engine` fix that goes
  green once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)