### PR TITLE
tempest: install netcat for reachability probes

### DIFF
--- a/tempest/Containerfile
+++ b/tempest/Containerfile
@@ -42,6 +42,7 @@ apt-get update
 apt-get install --no-install-recommends -y \
   build-essential \
   iputils-ping \
+  netcat-openbsd \
   openssh-client \
   patch
 python3 -m pip install --no-cache-dir --upgrade 'pip==26.1.2'

--- a/tempest/files/patches/0004-scenario-nc-client-missing-nc-error.patch
+++ b/tempest/files/patches/0004-scenario-nc-client-missing-nc-error.patch
@@ -1,0 +1,46 @@
+Subject: [PATCH] scenario: fail loudly when nc/ncat is missing on probe host
+
+BaseTempestTestCase.nc_client() runs the local/remote connectivity probe
+with shell.execute(..., check=False) and returns result.stdout without
+inspecting the exit status. When the host that runs the probe has no nc/ncat
+binary the command exits 127 ("command not found"), stdout is empty, and the
+caller treats the empty output as "port not reachable". Reachability tests
+(notably neutron_tempest_plugin.scenario.test_port_forwardings UDP cases)
+then retry until a misleading connectivity timeout that points at the data
+plane rather than the real cause -- a missing dependency in the test runner.
+
+Special-case exit status 127 and raise a RuntimeError naming the missing
+binary, so a missing netcat provider surfaces as a clear error instead of a
+false network-reachability failure. A genuine failed connection (nc present
+but unable to connect) still exits non-zero-but-not-127 and keeps the
+existing empty-stdout-and-retry semantics, so real reachability checks are
+unaffected.
+
+The OSISM tempest image separately ships netcat-openbsd so nc is present;
+this patch is defence-in-depth that turns any future missing-nc situation
+into an actionable error.
+
+Self-expiring: this patch is applied by the tempest image build with
+`patch --forward --dry-run` gating. When neutron-tempest-plugin is bumped to
+a release that fixes this upstream, the patch will no longer apply, the build
+will fail, and this file must be deleted.
+
+--- a/neutron_tempest_plugin/scenario/base.py
++++ b/neutron_tempest_plugin/scenario/base.py
+@@ -665,6 +665,16 @@
+         cmd = get_ncat_client_cmd(ip_address, port, protocol,
+                                   ssh_client=ssh_client)
+         result = shell.execute(cmd, ssh_client=ssh_client, check=False)
++        if result.exit_status == 127:
++            # 127 == "command not found". nc/ncat is missing on the host that
++            # runs this probe, so shell.execute(check=False) swallows the
++            # failure and returns empty stdout. Callers then interpret that as
++            # unreachable and retry until a misleading connectivity timeout.
++            # Fail loudly with the real cause instead.
++            raise RuntimeError(
++                "nc/ncat is not available where the connectivity probe runs "
++                "(command %r exited 127); install a netcat provider so "
++                "reachability tests can send traffic." % cmd)
+         return result.stdout
+ 
+     def _ensure_public_router(self, client=None, tenant_id=None):


### PR DESCRIPTION
## What

Fix false UDP port-forwarding reachability failures in the tempest image, caused by a missing `nc`/`ncat` binary rather than any OVN/product bug.

Two commits:

- `tempest/Containerfile` — add `netcat-openbsd` (provides `nc`) to the persistent apt-get install list. This is the actual fix.
- `tempest/files/patches/0004-scenario-nc-client-missing-nc-error.patch` — defence-in-depth: make `neutron_tempest_plugin` `nc_client()` raise a clear error on exit 127 instead of returning empty stdout.

## Why

The image shipped neither `nc` nor `ncat`. `neutron_tempest_plugin.scenario.base.nc_client()` builds its local connectivity probe as `echo ... | nc ...`; with no netcat binary the command exits 127 (`/bin/sh: nc: not found`). `shell.execute(check=False)` discards that status and returns empty stdout, which the caller reads as "port not reachable" and retries to a misleading timeout.

This turned healthy data-plane behaviour into false failures:

- `PortForwardingTestJSON.test_port_forwarding_editing_and_deleting_udp_rule`
- `PortForwardingTestJSON.test_port_forwarding_to_2_servers`

Both drive their reachability checks locally from the tempest host, so every probe failed before sending a packet.

## Validation

- Live repro on cloudpod confirmed OVN forward and reverse UDP NAT work correctly for fresh and edited rules; guest listeners bound successfully (34 stacked listeners accumulated over retries).
- Installing only `netcat-openbsd` into a throwaway copy of the stock `registry.osism.tech/osism/tempest:latest` image made both tests pass unchanged (86.3s and 143.8s), with no change to tbng/kolla-ansible/OVN.
- Patch 0004 generated from the pinned `neutron-tempest-plugin` 3.2.0 source and validated as the build applies it: `patch -p1 --forward --dry-run` applies clean, `ast.parse` on the result is valid, and re-apply is correctly detected as already-applied (self-expiry gating works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)