### PR TITLE
openstackclient: drop deprecated service clients

### DIFF
--- a/openstackclient/files/requirements.txt
+++ b/openstackclient/files/requirements.txt
@@ -1,13 +1,11 @@
 gnocchiclient
 osc-placement
 python-barbicanclient
-python-ceilometerclient
 python-cinderclient
 python-cloudkittyclient
 python-designateclient
 python-glanceclient
 python-heatclient
-python-ironic-inspector-client
 python-ironicclient
 python-keystoneclient
 python-magnumclient
@@ -18,10 +16,6 @@ python-neutronclient
 python-novaclient
 python-octaviaclient
 python-openstackclient
-python-senlinclient
-python-solumclient
 python-swiftclient
 python-troveclient
-python-vitrageclient
 python-watcherclient
-python-zunclient


### PR DESCRIPTION
Removes six per-service clients from `openstackclient/files/requirements.txt` that target services which are retired upstream, no longer developed, or no longer deployable with kolla-ansible.

This is the cleanup half of a pair; the other half is https://github.com/osism/python-osism/pull/2622, which adds the remaining plugins to the osism CLI container so `osism openstack loadbalancer …` works without the openstackclient container.

## Evidence for each removal

Three independent sources were checked for every entry: the OpenStack TC governance repo (`reference/legacy.yaml` vs. `reference/projects.yaml`), the client repository's own `master` README, and whether kolla-ansible still offers an `enable_*` flag for the service.

| Package | Governance | Repository README | kolla-ansible | In upper-constraints? |
|---|---|---|---|---|
| `python-ceilometerclient` | in [`legacy.yaml`](https://opendev.org/openstack/governance/raw/branch/master/reference/legacy.yaml) (retired) | [“This project is no longer maintained.”](https://opendev.org/openstack/python-ceilometerclient/raw/branch/master/README.rst) | `enable_ceilometer` exists, but Ceilometer has no API to talk to any more | **no** — absent from 2025.1, 2025.2, 2026.1 and master |
| `python-senlinclient` | in `legacy.yaml` (retired) | [“This project is no longer maintained.”](https://opendev.org/openstack/python-senlinclient/raw/branch/master/README.rst) | no `enable_senlin` in any built series | **no** — absent from 2025.1, 2025.2, 2026.1 and master |
| `python-solumclient` | in `legacy.yaml` (retired) | [“This project is no longer maintained.”](https://opendev.org/openstack/python-solumclient/raw/branch/master/README.rst) | no `enable_solum` in any built series | **no** — absent from 2025.1, 2025.2, 2026.1 and master |
| `python-ironic-inspector-client` | in `legacy.yaml` (retired) | [“This project is no longer maintained. … Please use built-in in-band inspection in ironic instead.”](https://opendev.org/openstack/python-ironic-inspector-client/raw/branch/master/README.rst) | no `enable_ironic_inspector` in any built series | yes (5.4.0) |
| `python-vitrageclient` | still in `projects.yaml` | [“This project is no longer being developed.”](https://opendev.org/openstack/python-vitrageclient/raw/branch/master/README.rst) | no `enable_vitrage` in any built series | yes (5.4.0) |
| `python-zunclient` | still in `projects.yaml` | no retirement notice | `enable_zun` **gone** from `master` and `stable/2026.1`, **still present** on `stable/2025.1` and `stable/2025.2` — see caveat below | yes (5.4.0) |

The upper-constraints column was checked against `upper-constraints.txt` on [`master`](https://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt), [`stable/2026.1`](https://opendev.org/openstack/requirements/raw/branch/stable/2026.1/upper-constraints.txt), [`stable/2025.2`](https://opendev.org/openstack/requirements/raw/branch/stable/2025.2/upper-constraints.txt) and [`stable/2025.1`](https://opendev.org/openstack/requirements/raw/branch/stable/2025.1/upper-constraints.txt) — the four series the build matrix in `.github/workflows/build-openstackclient-container-image.yml` covers.

The kolla-ansible column was checked against `etc/kolla/globals.yml` on [`master`](https://opendev.org/openstack/kolla-ansible/raw/branch/master/etc/kolla/globals.yml) and the three stable branches.

## Three of these were already no-ops

`python-ceilometerclient`, `python-senlinclient` and `python-solumclient` are not in the upper-constraints of any series this image builds. The `Containerfile` filters `requirements.txt` through upper-constraints before installing:

```
while read -r package; do
  grep -q "$package" /requirements/upper-constraints.txt && \
  echo "$package" >> /packages.txt || true;
done < /requirements.txt
```

so those three were silently skipped and never actually installed. Removing them only deletes dead entries — no image content changes.

The other three (`python-ironic-inspector-client`, `python-vitrageclient`, `python-zunclient`) *are* in upper-constraints and *are* currently installed, so those three do shrink the image.

## ⚠️ Caveat worth a decision: `python-zunclient`

Zun is the one entry that is not clear-cut, and I want a second opinion on it before this leaves draft.

- Zun is **not** retired in governance and its client carries no retirement notice.
- `enable_zun` was dropped from kolla-ansible `etc/kolla/globals.yml` on `master` and `stable/2026.1`.
- But it **still exists** on `stable/2025.1` and `stable/2025.2`, and this image is built for those series from this same `requirements.txt`.

So removing it also removes `openstack appcontainer …` from the 2025.1 and 2025.2 images, where a user could still legitimately be running Zun. If that is not acceptable, drop this one line from the commit and keep `python-zunclient`; the other five removals stand on their own.

## Everything else was deliberately kept

`gnocchiclient`, `osc-placement`, `python-barbicanclient`, `python-cinderclient`, `python-cloudkittyclient`, `python-designateclient`, `python-glanceclient`, `python-heatclient`, `python-ironicclient`, `python-keystoneclient`, `python-magnumclient`, `python-manilaclient`, `python-masakariclient`, `python-mistralclient`, `python-neutronclient`, `python-novaclient`, `python-octaviaclient`, `python-openstackclient`, `python-swiftclient`, `python-troveclient`, `python-watcherclient`.

Each of these still has a corresponding `enable_*` flag in kolla-ansible `master` (Mistral, Trove, Masakari, CloudKitty, Gnocchi and Watcher included — all still deployable) and is present in the master upper-constraints. Gnocchi has left OpenStack governance but is maintained at gnocchixyz and still deployable via `enable_gnocchi`, so `gnocchiclient` stays.

## Not addressed here

`aodhclient` is missing from this list even though `enable_aodh` exists in kolla-ansible and `aodhclient===3.11.0` is in the master upper-constraints — so `openstack alarm …` does not work in this image today. Now that `python-ceilometerclient` is gone it would be the only telemetry CLI left. Same situation, less pressing, for `python-blazarclient`, `python-cyborgclient` and `python-tackerclient` (all deployable via kolla, all in upper-constraints, none ever listed here). Left out of this PR to keep it a pure removal — happy to add them in a follow-up if wanted.
