### PR TITLE
tempest: stop diagnostics masking real failures

### DIFF
--- a/tempest/files/patches/0005-scenario-diagnostics-must-not-mask-failure.patch
+++ b/tempest/files/patches/0005-scenario-diagnostics-must-not-mask-failure.patch
@@ -1,0 +1,63 @@
+Subject: [PATCH] scenario: never let diagnostics replace the real failure
+
+BaseTempestTestCase._log_local_network_status() is called from eight
+exception handlers in this module, always to enrich a failure that has
+already happened. It calls ip_utils.IPCommand().list_namespaces(), which
+shells out to `sudo /sbin/ip netns`.
+
+IPCommand() is constructed without an ssh_client, so it falls back to a proxy
+client that only exists when [neutron_plugin_options] ssh_proxy_jump_host is
+configured -- absent by default. With no client the command runs as a local
+subprocess inside the tempest runner container, which has no sudo binary, so
+the diagnostic itself raises:
+
+    neutron_tempest_plugin.exceptions.ShellCommandFailed: Command
+    "sudo '/sbin/ip' netns " failed, exit status: 127, stderr:
+    /bin/sh: 1: sudo: not found
+
+Because this happens inside an `except` block, the diagnostic failure becomes
+the outermost exception in the chain. Three consequences, all bad:
+
+1. The real failure is buried. `stestr last` and any log tail show the
+   diagnostic error; recovering the actual cause means walking the whole
+   exception chain, which is easy to miss.
+2. Tests that would have PASSED fail. Callers catch the exceptions their
+   assertions raise -- e.g. test_port_forwardings' fip_pf_connectivity()
+   catches (AssertionError, SSHTimeout) and lets wait_until_true() retry --
+   but nothing catches ShellCommandFailed, so it escapes the retry helper and
+   fails the test on a condition the test was written to tolerate.
+3. It is silent about itself. The failure looks like a data-plane problem in
+   whatever was under test, so it is investigated as one.
+
+A diagnostic must never be able to change the outcome it is describing. Wrap
+the collection so any failure is logged and swallowed. The one function covers
+all eight call sites.
+
+Deliberately broad `except Exception`: this is a best-effort enrichment path,
+every exception from it is by definition not the failure under investigation,
+and letting any of them through is the bug being fixed.
+
+--- a/neutron_tempest_plugin/scenario/base.py
++++ b/neutron_tempest_plugin/scenario/base.py
+@@ -388,9 +388,18 @@
+                           "for the console log", server['id'])
+ 
+     def _log_local_network_status(self):
+-        self._log_ns_network_status()
+-        for ns_name in ip_utils.IPCommand().list_namespaces():
+-            self._log_ns_network_status(ns_name=ns_name)
++        # Best-effort: this runs from inside `except` blocks, so an exception
++        # raised here would replace the failure being diagnosed -- burying the
++        # real cause and failing tests whose own retry helpers catch only the
++        # exceptions their assertions raise.
++        try:
++            self._log_ns_network_status()
++            for ns_name in ip_utils.IPCommand().list_namespaces():
++                self._log_ns_network_status(ns_name=ns_name)
++        except Exception as diag_exc:
++            LOG.debug("Could not collect local network status (%s: %s); "
++                      "continuing so the original failure is preserved.",
++                      type(diag_exc).__name__, diag_exc)
+ 
+     def _log_ns_network_status(self, ns_name=None):
+         try:


### PR DESCRIPTION
Adds `tempest/files/patches/0005-scenario-diagnostics-must-not-mask-failure.patch`.

## The problem

`neutron_tempest_plugin/scenario/base.py::_log_local_network_status()` is called from **eight** exception handlers, always to enrich a failure that has already happened. It calls `ip_utils.IPCommand().list_namespaces()`, which shells out to `sudo /sbin/ip netns`.

`IPCommand()` is constructed without an `ssh_client`, so it falls back to a proxy client that only exists when `[neutron_plugin_options] ssh_proxy_jump_host` is configured — absent by default. With no client the command runs as a local subprocess inside the tempest runner container, which has no `sudo`, so the diagnostic itself raises:

```
neutron_tempest_plugin.exceptions.ShellCommandFailed: Command "sudo '/sbin/ip' netns " failed, exit status: 127
/bin/sh: 1: sudo: not found
```

Because this happens **inside an `except` block**, the diagnostic failure becomes the outermost exception in the chain. Three consequences:

1. **The real failure is buried.** `stestr last` and any log tail show the diagnostic error; recovering the actual cause means walking the whole exception chain.
2. **Tests that would have passed fail.** `test_port_forwardings`' `fip_pf_connectivity()` catches `(AssertionError, SSHTimeout)` so `wait_until_true()` can retry — but nothing catches `ShellCommandFailed`, so it escapes the retry helper on a condition the test was written to tolerate.
3. **It is silent about itself.** The failure reads as a data-plane problem in whatever was under test, so it gets investigated as one.

On a full-profile OSISM run this masked **7 of 19** tempest failures, and led to two separate investigations chasing a data-plane fault that did not exist — the second re-derived the same conclusion a month later.

## The fix

Wrap the collection so any exception is logged and swallowed. One function covers all eight call sites. No behaviour change on the success path.

The sibling `_log_ns_network_status()` already guards its inner `ip_utils` calls against `ShellCommandFailed`; the `list_namespaces()` call in the outer function is the one left unguarded.

`except Exception` is deliberately broad and argued in the patch header: this is a best-effort enrichment path, every exception from it is by definition *not* the failure under investigation, and letting any through is the bug being fixed.

## Verification

Against the shipped image (`registry.osism.tech/osism/tempest:latest`), before and after:

| check | result |
|---|---|
| `patch --forward --batch --dry-run` (build gate) | OK |
| apply | clean |
| **unpatched**, stubbed diagnostic raising | **propagates** `RuntimeError` |
| **patched**, same stub | **swallowed**, execution continues |

**End-to-end on a live cluster.** The image was rebuilt with this patch and the whole `test_port_forwardings` class re-run against an OSISM 10.2.0 deployment — covering both the two tests that failed before and the two that did not:

```
scenario...test_port_forwarding_editing_and_deleting_tcp_rule [105.594125s] ... ok
scenario...test_port_forwarding_to_2_fixed_ips                [111.677249s] ... ok
scenario...test_port_forwarding_editing_and_deleting_udp_rule [ 91.894985s] ... ok
scenario...test_port_forwarding_to_2_servers                  [154.999920s] ... ok
 - Passed: 10
 - Failed: 0
```

The durations confirm the mechanism rather than just the result: `tcp_rule` now takes **105.6s** where it previously died at **85.8s**. It spends that extra time retrying through the transient reconnect the test was written to tolerate, instead of being killed by the diagnostic raising inside the handler.

## Scope

This fixes the **masking**, not the underlying condition. For the two `test_port_forwardings` cases the underlying event is a `TimeoutError` on SSH reconnect just after a `PUT` that edits the forwarding — benign and transient, and the tests already tolerate it once the diagnostic stops hijacking the exception. Verified by hand on a live cluster: create PF on 1046 → reachable; `PUT` to 3333 → 1046 refuses and 3333 answers, so the mutation itself works.

The patch file is written to be upstream-submittable as-is; the self-expiry contract (build dry-run gate fails once upstream carries an equivalent fix, at which point the patch must be deleted) is recorded in the commit message rather than in the patch.

## Why this was never caught upstream — and why installing `sudo` is not the fix

neutron-tempest-plugin is exercised on a **devstack node**, where tempest runs on the host that owns the namespaces, as a user with passwordless `sudo` and `iproute2` present. There `sudo ip netns` works and enumerates the real `qrouter-*`/`qdhcp-*` namespaces, so this failure path is unreachable.

The code carries that assumption openly. The function is `_log_**local**_network_status`, and the sibling's handler reads:

```python
except exceptions.ShellCommandFailed:
    LOG.debug('Namespace %s has been deleted synchronously during the '
              'host network collection process', ns_name)
```

"host network collection process" — the premise is that the runner *is* the host. Note also what it hardens against: a namespace vanishing **mid-enumeration**, a race that only exists when you are genuinely enumerating live namespaces. The guard covers the failure mode that environment produces, not "the command does not exist", which there is impossible.

Upstream did anticipate remote runners — `[neutron_plugin_options] ssh_proxy_jump_host` exists so `IPCommand()` can run elsewhere. The gap is that when it is unset, `IPCommand()` silently degrades to *local* execution instead of skipping collection.

**So the obvious remedy does not work.** This image runs as a non-root user and has neither binary:

```
whoami: dragon (uid 45000)
sudo  -> MISSING
ip    -> MISSING
```

`ip_utils` hardcodes `sudo = 'sudo'` and builds `'{sudo} {ip_path}'`, with `sudo ip netns exec ...` hardcoded in three further places — so installing `sudo` just moves the failure to `ip`. And with **both** installed it would enumerate the *container's* namespaces rather than the network node's, producing confidently useless diagnostics.

That leaves two coherent options: make the diagnostic non-fatal (this PR — correct regardless of environment), or configure `ssh_proxy_jump_host` so collection happens somewhere real. Adding packages is the one option that looks like a fix and is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

